### PR TITLE
bugfix: unregister old gauge

### DIFF
--- a/concurrency-limits-spectator/src/main/java/com/netflix/concurrency/limits/spectator/SpectatorMetricRegistry.java
+++ b/concurrency-limits-spectator/src/main/java/com/netflix/concurrency/limits/spectator/SpectatorMetricRegistry.java
@@ -25,8 +25,11 @@ public final class SpectatorMetricRegistry implements MetricRegistry {
 
     @Override
     public void registerGauge(String id, Supplier<Number> supplier, String... tagNameValuePairs) {
+        Id metricId = suffixBaseId(id).withTags(tagNameValuePairs);
+        PolledMeter.remove(registry, metricId);
+        
         PolledMeter.using(registry)
-            .withId(suffixBaseId(id).withTags(tagNameValuePairs))
+            .withId(metricId)
             .monitorValue(supplier, ignore -> supplier.get().doubleValue());
     }
     


### PR DESCRIPTION
When recreating a gauge with the same id force remove the old one so values don't accumulate