### PR TITLE
Use compareAndSet in SimpleStrategy#tryAcquire

### DIFF
--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/strategy/SimpleStrategyTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/strategy/SimpleStrategyTest.java
@@ -1,5 +1,11 @@
 package com.netflix.concurrency.limits.strategy;
 
+import com.netflix.concurrency.limits.internal.EmptyMetricRegistry;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import com.netflix.concurrency.limits.Strategy.Token;
@@ -51,5 +57,29 @@ public class SimpleStrategyTest {
 
         Assert.assertTrue(strategy.tryAcquire(null).isAcquired());
         Assert.assertEquals(1, strategy.getBusyCount());
+    }
+
+    @Test
+    public void tryAcquireWithMultipleThreads() throws Exception {
+        CountDownLatch latch = new CountDownLatch(2);
+        Runnable acquireBarrier = () -> {
+            latch.countDown();
+            try {
+                Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+        SimpleStrategy<Void> strategy = new SimpleStrategy<>(
+            EmptyMetricRegistry.INSTANCE,
+            acquireBarrier);
+        strategy.setLimit(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        Future<Token> future1 = executor.submit(() -> strategy.tryAcquire(null));
+        Future<Token> future2 = executor.submit(() -> strategy.tryAcquire(null));
+
+        // Assert only 1 thread acquired a token.
+        Assert.assertTrue(future1.get().isAcquired() != future2.get().isAcquired());
     }
 }


### PR DESCRIPTION
Busy is modified after reading, so it needs a compareAndSet to guard
against concurrent modifications.

Assume busy == limit - 1. Only 1 thread should be allowed a Token.

Thread 1:
current = busy.get()
check current < limit

Thread 2:
current = busy.get()
check current < limit

Thread 1:
increment busy

Both Thread 1 and Thread 2 were allowed a Token.

A test hook was added to the tryAcquire method to allow testing multiple
threads and ensuring the CAS loop works.