### PR TITLE
Use pathToGroup function argument in ServletLimiterBuilder

### DIFF
--- a/concurrency-limits-servlet/src/main/java/com/netflix/concurrency/limits/servlet/ServletLimiterBuilder.java
+++ b/concurrency-limits-servlet/src/main/java/com/netflix/concurrency/limits/servlet/ServletLimiterBuilder.java
@@ -39,7 +39,7 @@ public final class ServletLimiterBuilder extends AbstractLimiterBuilder<ServletL
      */
     public ServletLimiterBuilder partitionByUserPrincipal(Function<Principal, String> principalToGroup, Consumer<LookupPartitionStrategy.Builder<HttpServletRequest>> configurer) {
         return partitionByLookup(
-                request -> Optional.ofNullable(request.getUserPrincipal()).map(principalToGroup) .orElse(null),
+                request -> Optional.ofNullable(request.getUserPrincipal()).map(principalToGroup).orElse(null),
                 configurer);
     }
     
@@ -77,7 +77,7 @@ public final class ServletLimiterBuilder extends AbstractLimiterBuilder<ServletL
      */
     public ServletLimiterBuilder partitionByPathInfo(Function<String, String> pathToGroup, Consumer<LookupPartitionStrategy.Builder<HttpServletRequest>> configurer) {
         return partitionByLookup(
-                request -> Optional.ofNullable(request.getPathInfo()).orElse(null),
+                request -> Optional.ofNullable(request.getPathInfo()).map(pathToGroup).orElse(null),
                 configurer);
     }
     

--- a/concurrency-limits-servlet/src/test/com/netflix/concurrency/limits/GroupServletLimiterTest.java
+++ b/concurrency-limits-servlet/src/test/com/netflix/concurrency/limits/GroupServletLimiterTest.java
@@ -13,26 +13,19 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class GroupServletLimiterTest {
-    private static final Map<String, String> principalToGroup = Mockito.spy(new HashMap<>());
-    
-    static {
-        principalToGroup.put("bob", "live");
-    }
-    
-    HttpServletRequest createMockRequestWithPrincipal(String name) {
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        Principal principal = Mockito.mock(Principal.class);
-        
-        Mockito.when(request.getUserPrincipal()).thenReturn(principal);
-        Mockito.when(principal.getName()).thenReturn(name);
-        return request;
-    }
-    
+
     @Test
     public void userPrincipalMatchesGroup() {
+        Map<String, String> principalToGroup = Mockito.spy(new HashMap<>());
+        principalToGroup.put("bob", "live");
+
         Limiter<HttpServletRequest> limiter = new ServletLimiterBuilder()
                 .limit(VegasLimit.newDefault())
                 .partitionByUserPrincipal(p -> principalToGroup.get(p.getName()), builder -> builder
@@ -49,6 +42,9 @@ public class GroupServletLimiterTest {
 
     @Test
     public void userPrincipalDoesNotMatchGroup() {
+        Map<String, String> principalToGroup = Mockito.spy(new HashMap<>());
+        principalToGroup.put("bob", "live");
+
         Limiter<HttpServletRequest> limiter = new ServletLimiterBuilder()
                 .limit(VegasLimit.newDefault())
                 .partitionByUserPrincipal(p -> principalToGroup.get(p.getName()), builder -> builder
@@ -64,7 +60,31 @@ public class GroupServletLimiterTest {
     }
 
     @Test
-    public void nullUserPrincipal() {
+    public void nullUserPrincipalDoesNotMatchGroup() {
+        Map<String, String> principalToGroup = Mockito.spy(new HashMap<>());
+        principalToGroup.put("bob", "live");
+
+        Limiter<HttpServletRequest> limiter = new ServletLimiterBuilder()
+                .limit(VegasLimit.newDefault())
+                .partitionByUserPrincipal(p -> principalToGroup.get(p.getName()), builder -> builder
+                    .assign("live", 0.8)
+                    .assign("batch", 0.2))
+                .build();
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getUserPrincipal()).thenReturn(null);
+
+        Optional<Listener> listener =  limiter.acquire(request);
+
+        Assert.assertTrue(listener.isPresent());
+        Mockito.verify(principalToGroup, Mockito.times(0)).get(Mockito.<String> any());
+    }
+
+    @Test
+    public void nullUserPrincipalNameDoesNotMatchGroup() {
+        Map<String, String> principalToGroup = Mockito.spy(new HashMap<>());
+        principalToGroup.put("bob", "live");
+
         Limiter<HttpServletRequest> limiter = new ServletLimiterBuilder()
                 .limit(VegasLimit.newDefault())
                 .partitionByUserPrincipal(p -> principalToGroup.get(p.getName()), builder -> builder
@@ -76,6 +96,79 @@ public class GroupServletLimiterTest {
         Optional<Listener> listener =  limiter.acquire(request);
         
         Assert.assertTrue(listener.isPresent());
-        Mockito.verify(principalToGroup, Mockito.never());
+        Mockito.verify(principalToGroup, Mockito.times(1)).get(Matchers.isNull(String.class));
+    }
+
+    @Test
+    public void pathMatchesGroup() {
+        Map<String, String> pathToGroup = Mockito.spy(new HashMap<>());
+        pathToGroup.put("/live/path", "live");
+
+        Limiter<HttpServletRequest> limiter = new ServletLimiterBuilder()
+                .limit(VegasLimit.newDefault())
+                .partitionByPathInfo(pathToGroup::get, builder -> builder
+                    .assign("live", 0.8)
+                    .assign("batch", 0.2))
+                .build();
+
+        HttpServletRequest request = createMockRequestWithPathInfo("/live/path");
+        Optional<Listener> listener = limiter.acquire(request);
+
+        Assert.assertTrue(listener.isPresent());
+        Mockito.verify(pathToGroup, Mockito.times(1)).get("/live/path");
+    }
+
+    @Test
+    public void pathDoesNotMatchesGroup() {
+        Map<String, String> pathToGroup = Mockito.spy(new HashMap<>());
+        pathToGroup.put("/live/path", "live");
+
+        Limiter<HttpServletRequest> limiter = new ServletLimiterBuilder()
+                .limit(VegasLimit.newDefault())
+                .partitionByPathInfo(pathToGroup::get, builder -> builder
+                    .assign("live", 0.8)
+                    .assign("batch", 0.2))
+                .build();
+
+        HttpServletRequest request = createMockRequestWithPathInfo("/other/path");
+        Optional<Listener> listener = limiter.acquire(request);
+
+        Assert.assertTrue(listener.isPresent());
+        Mockito.verify(pathToGroup, Mockito.times(1)).get("/other/path");
+    }
+
+    @Test
+    public void nullPathDoesNotMatchesGroup() {
+        Map<String, String> pathToGroup = Mockito.spy(new HashMap<>());
+        pathToGroup.put("/live/path", "live");
+
+        Limiter<HttpServletRequest> limiter = new ServletLimiterBuilder()
+                .limit(VegasLimit.newDefault())
+                .partitionByPathInfo(pathToGroup::get, builder -> builder
+                    .assign("live", 0.8)
+                    .assign("batch", 0.2))
+                .build();
+
+        HttpServletRequest request = createMockRequestWithPathInfo(null);
+        Optional<Listener> listener = limiter.acquire(request);
+
+        Assert.assertTrue(listener.isPresent());
+        Mockito.verify(pathToGroup, Mockito.times(0)).get(Mockito.<String> any());
+    }
+
+    private HttpServletRequest createMockRequestWithPrincipal(String name) {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Principal principal = Mockito.mock(Principal.class);
+
+        Mockito.when(request.getUserPrincipal()).thenReturn(principal);
+        Mockito.when(principal.getName()).thenReturn(name);
+        return request;
+    }
+
+    private HttpServletRequest createMockRequestWithPathInfo(String name) {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        Mockito.when(request.getPathInfo()).thenReturn(name);
+        return request;
     }
 }


### PR DESCRIPTION
Looks like there's a bug in ServletLimiterBuilder where the method partitionByPathInfo wasn't using the pathToGroup function. Fixed and updated the tests