### PR TITLE
Probe for more up to date noload RTT

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/Limit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/Limit.java
@@ -17,12 +17,12 @@ public interface Limit {
         /**
          * @return Maximum number of inflight observed during the sample window
          */
-        long getMaxInFlight();
+        int getMaxInFlight();
         
         /**
          * @return Number of observed RTTs in the sample window
          */
-        long getSampleCount();
+        int getSampleCount();
         
         /**
          * @return True if there was a timeout

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/MetricIds.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/MetricIds.java
@@ -7,9 +7,9 @@ public final class MetricIds {
     public static final String LIMIT_GUAGE_NAME = "limit";
     public static final String INFLIGHT_GUAGE_NAME = "inflight";
     public static final String PARTITION_LIMIT_GUAGE_NAME = "limit.partition";
-    public static final String MIN_RTT_GUAGE_NAME = "min_rtt";
-    public static final String WINDOW_MIN_RTT_GUAGE_NAME = "min_window_rtt";
-    public static final String WINDOW_QUEUE_SIZE_GUAGE_NAME = "queue_size";
+    public static final String MIN_RTT_NAME = "min_rtt";
+    public static final String WINDOW_MIN_RTT_NAME = "min_window_rtt";
+    public static final String WINDOW_QUEUE_SIZE_NAME = "queue_size";
 
     private MetricIds() {}
 }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/Measurement.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/Measurement.java
@@ -1,0 +1,23 @@
+package com.netflix.concurrency.limits.limit;
+
+/**
+ * Contract for tracking a measurement such as a minimum or average of a sample set
+ */
+public interface Measurement {
+    /**
+     * Add a single sample and update the internal state.
+     * @param sample
+     * @return True if internal state was updated
+     */
+    boolean add(long sample);
+    
+    /**
+     * @return Return the current value
+     */
+    long get();
+    
+    /**
+     * Reset the internal state as if no samples were ever added
+     */
+    void reset();
+}

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/MinimumMeasurement.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/MinimumMeasurement.java
@@ -1,0 +1,25 @@
+package com.netflix.concurrency.limits.limit;
+
+public class MinimumMeasurement implements Measurement {
+    private long value = 0;
+    
+    @Override
+    public boolean add(long sample) {
+        if (value == 0 || sample < value) {
+            value = sample;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public long get() {
+        return value;
+    }
+
+    @Override
+    public void reset() {
+        value = 0;
+    }
+
+}

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/ImmutableSample.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/ImmutableSample.java
@@ -7,8 +7,8 @@ import com.netflix.concurrency.limits.Limit;
  */
 public class ImmutableSample implements Limit.SampleWindow {
     final long minRtt;
-    final long maxInFlight;
-    final long sampleCount;
+    final int maxInFlight;
+    final int sampleCount;
     final boolean didDrop;
     
     public ImmutableSample() {
@@ -22,18 +22,18 @@ public class ImmutableSample implements Limit.SampleWindow {
         return new ImmutableSample();
     }
 
-    public ImmutableSample(long minRtt, long maxInFlight, long sampleCount, boolean didDrop) {
+    public ImmutableSample(long minRtt, int maxInFlight, int sampleCount, boolean didDrop) {
         this.minRtt = minRtt;
         this.maxInFlight = maxInFlight;
         this.sampleCount = sampleCount;
         this.didDrop = didDrop;
     }
     
-    public ImmutableSample addSample(long rtt, long maxInFlight) {
+    public ImmutableSample addSample(long rtt, int maxInFlight) {
         return new ImmutableSample(Math.min(rtt, minRtt), Math.max(maxInFlight, this.maxInFlight), sampleCount+1, didDrop);
     }
     
-    public ImmutableSample addDroppedSample(long maxInFlight) {
+    public ImmutableSample addDroppedSample(int maxInFlight) {
         return new ImmutableSample(minRtt, Math.max(maxInFlight, this.maxInFlight), sampleCount+1, true);
     }
     
@@ -43,12 +43,12 @@ public class ImmutableSample implements Limit.SampleWindow {
     }
 
     @Override
-    public long getMaxInFlight() {
+    public int getMaxInFlight() {
         return maxInFlight;
     }
 
     @Override
-    public long getSampleCount() {
+    public int getSampleCount() {
         return sampleCount;
     }
 

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/AIMDLimitTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/AIMDLimitTest.java
@@ -18,14 +18,14 @@ public class AIMDLimitTest {
     @Test
     public void increaseOnSuccess() {
         AIMDLimit limiter = AIMDLimit.newBuilder().initialLimit(10).build();
-        limiter.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(1), 10L));
+        limiter.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(1), 10));
         Assert.assertEquals(11, limiter.getLimit());
     }
 
     @Test
     public void decreaseOnDrops() {
         AIMDLimit limiter = AIMDLimit.newBuilder().initialLimit(10).build();
-        limiter.update(new ImmutableSample().addDroppedSample(1L));
+        limiter.update(new ImmutableSample().addDroppedSample(1));
         Assert.assertEquals(9, limiter.getLimit());
     }
 }

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
@@ -28,27 +28,27 @@ public class VegasLimitTest {
     @Test
     public void increaseLimit() {
         VegasLimit limit = create();
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
         Assert.assertEquals(11, limit.getLimit());
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 11L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 11));
         Assert.assertEquals(12, limit.getLimit());
     }
     
     @Test
     public void decreaseLimit() {
         VegasLimit limit = create();
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
         Assert.assertEquals(11, limit.getLimit());
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(50), 11L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(50), 11));
         Assert.assertEquals(10, limit.getLimit());
     }
     
     @Test
     public void noChangeIfWithinThresholds() {
         VegasLimit limit = create();
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
         Assert.assertEquals(11, limit.getLimit());
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(14), 14L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(14), 14));
         Assert.assertEquals(11, limit.getLimit());
     }
     
@@ -62,15 +62,15 @@ public class VegasLimitTest {
             .build();
         
         // Pick up first min-rtt
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 100L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 100));
         Assert.assertEquals(100, limit.getLimit());
         
         // First decrease
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
         Assert.assertEquals(75, limit.getLimit());
 
         // Second decrease
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
         Assert.assertEquals(56, limit.getLimit());
     }
 
@@ -83,15 +83,15 @@ public class VegasLimitTest {
             .build();
         
         // Pick up first min-rtt
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 100L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 100));
         Assert.assertEquals(101, limit.getLimit());
         
         // First decrease
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
         Assert.assertEquals(50, limit.getLimit());
 
         // Second decrease
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100L));
+        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
         Assert.assertEquals(25, limit.getLimit());
     }
 }


### PR DESCRIPTION
- For the 'gradient' limiter allow for probing for an up to date noload RTT
- Less aggressive min rtt threshold of (1 us) now that we can probe for better RTT
- Make the sample window size relative to the last min RTT and not the absolute min RTT to get a more meaningful sample size
- Track metrics as distributions and not gauges for better visibility