### PR TITLE
Improve probing for new noload RTT in gradient

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/Measurement.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/Measurement.java
@@ -1,5 +1,7 @@
 package com.netflix.concurrency.limits.limit;
 
+import java.util.function.Function;
+
 /**
  * Contract for tracking a measurement such as a minimum or average of a sample set
  */
@@ -10,6 +12,8 @@ public interface Measurement {
      * @return True if internal state was updated
      */
     boolean add(long sample);
+    
+    long update(Function<Long, Long> func);
     
     /**
      * @return Return the current value

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/MinimumMeasurement.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/MinimumMeasurement.java
@@ -1,5 +1,7 @@
 package com.netflix.concurrency.limits.limit;
 
+import java.util.function.Function;
+
 public class MinimumMeasurement implements Measurement {
     private long value = 0;
     
@@ -22,4 +24,9 @@ public class MinimumMeasurement implements Measurement {
         value = 0;
     }
 
+    @Override
+    public long update(Function<Long, Long> func) {
+        value = func.apply(value);
+        return value;
+    }
 }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/ImmutableSample.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/ImmutableSample.java
@@ -2,6 +2,8 @@ package com.netflix.concurrency.limits.limiter;
 
 import com.netflix.concurrency.limits.Limit;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Class used to track immutable samples in an AtomicReference
  */
@@ -12,16 +14,12 @@ public class ImmutableSample implements Limit.SampleWindow {
     final boolean didDrop;
     
     public ImmutableSample() {
-        this.minRtt = Integer.MAX_VALUE;
+        this.minRtt = Long.MAX_VALUE;
         this.maxInFlight = 0;
         this.sampleCount = 0;
         this.didDrop = false;
     }
     
-    public ImmutableSample reset() {
-        return new ImmutableSample();
-    }
-
     public ImmutableSample(long minRtt, int maxInFlight, int sampleCount, boolean didDrop) {
         this.minRtt = minRtt;
         this.maxInFlight = maxInFlight;
@@ -34,7 +32,7 @@ public class ImmutableSample implements Limit.SampleWindow {
     }
     
     public ImmutableSample addDroppedSample(int maxInFlight) {
-        return new ImmutableSample(minRtt, Math.max(maxInFlight, this.maxInFlight), sampleCount+1, true);
+        return new ImmutableSample(minRtt, Math.max(maxInFlight, this.maxInFlight), sampleCount, true);
     }
     
     @Override
@@ -55,5 +53,11 @@ public class ImmutableSample implements Limit.SampleWindow {
     @Override
     public boolean didDrop() {
         return didDrop;
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableSample [minRtt=" + TimeUnit.NANOSECONDS.toMicros(minRtt) / 1000.0 + ", maxInFlight=" + maxInFlight + ", sampleCount=" + sampleCount
+                + ", didDrop=" + didDrop + "]";
     }
 }

--- a/concurrency-limits-grpc/build.gradle
+++ b/concurrency-limits-grpc/build.gradle
@@ -15,4 +15,5 @@ dependencies {
     testCompile "io.grpc:grpc-stub:1.9.0"
     testCompile "junit:junit-dep:4.10"
     testCompile "org.slf4j:slf4j-log4j12:1.7.+"
+    testCompile "org.apache.commons:commons-math3:3.6.1"
 }

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/Example.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/Example.java
@@ -1,0 +1,114 @@
+package com.netflix.concurrency.limits.grpc.server.example;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.netflix.concurrency.limits.grpc.StringMarshaller;
+import com.netflix.concurrency.limits.grpc.server.ConcurrencyLimitServerInterceptor;
+import com.netflix.concurrency.limits.grpc.server.GrpcServerLimiterBuilder;
+import com.netflix.concurrency.limits.limit.GradientLimit;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.Server;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptors;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.ServerCalls;
+import io.grpc.stub.StreamObserver;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.apache.commons.math3.distribution.ExponentialDistribution;
+
+public class Example {
+    private static final MethodDescriptor<String, String> METHOD_DESCRIPTOR = MethodDescriptor.<String, String>newBuilder()
+            .setType(MethodType.UNARY)
+            .setFullMethodName("service/method")
+            .setRequestMarshaller(StringMarshaller.INSTANCE)
+            .setResponseMarshaller(StringMarshaller.INSTANCE)
+            .build();
+
+    public static ServerCallHandler<String, String> createServerHandler(int concurrency) {
+        final ExponentialDistribution distribution = new ExponentialDistribution(10.0);
+        final Supplier<Integer> latency = () -> 100 + (int)distribution.sample();
+        final Semaphore sem = new Semaphore(concurrency, true);
+        
+        return ServerCalls.asyncUnaryCall((req, observer) -> {
+            try {
+                sem.acquire();
+                Uninterruptibles.sleepUninterruptibly(latency.get(), TimeUnit.MILLISECONDS);
+                observer.onNext("response");
+                observer.onCompleted();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                observer.onError(Status.UNKNOWN.asRuntimeException());
+            } finally {
+                sem.release();
+            }
+        });
+    }
+    
+    public static void main(String[] args) throws IOException {
+        GradientLimit limit = GradientLimit.newBuilder()
+                .build();
+        
+        // Create a server
+        Server server = NettyServerBuilder.forPort(0)
+            .addService(ServerInterceptors.intercept(ServerServiceDefinition.builder("service")
+                    .addMethod(METHOD_DESCRIPTOR, createServerHandler(20))
+                    .build(), new ConcurrencyLimitServerInterceptor(new GrpcServerLimiterBuilder()
+                            .limiter(builder -> builder
+                                    .limit(limit)
+                                    .minWindowTime(200, TimeUnit.MILLISECONDS)
+                                    )
+                            .build())
+                ))
+            .build()
+            .start();
+        
+        // Report progress
+        AtomicInteger dropCount = new AtomicInteger(0);
+        AtomicInteger successCount = new AtomicInteger(0);
+        
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+            System.out.println(MessageFormat.format("{0}, {1}, {2}", limit.getLimit(), successCount.getAndSet(0), dropCount.getAndSet(0)));
+        }, 1, 1, TimeUnit.SECONDS);
+        
+        // Create a client
+        Channel channel = NettyChannelBuilder.forTarget("localhost:" + server.getPort())
+                .usePlaintext(true)
+                .build();
+
+        while (true) {
+            Uninterruptibles.sleepUninterruptibly(6, TimeUnit.MILLISECONDS);
+            ClientCalls.asyncUnaryCall(channel.newCall(METHOD_DESCRIPTOR, CallOptions.DEFAULT.withWaitForReady()), "request",
+                new StreamObserver<String>() {
+                    @Override
+                    public void onNext(String value) {
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        dropCount.incrementAndGet();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        successCount.incrementAndGet();
+                    }
+                
+            });
+        }
+    }
+}


### PR DESCRIPTION
- Fix bug filtering sample window for high noload RTT
- Continue using the existing sample window when it fails the filter to avoid starving the algorithm
- Set limit to queueSize when probing for minRtt
- Add GRPC example