### PR TITLE
Make RTT probing less aggressive

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/ImmutableSampleWindow.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/ImmutableSampleWindow.java
@@ -7,32 +7,32 @@ import java.util.concurrent.TimeUnit;
 /**
  * Class used to track immutable samples in an AtomicReference
  */
-public class ImmutableSample implements Limit.SampleWindow {
+public class ImmutableSampleWindow implements Limit.SampleWindow {
     final long minRtt;
     final int maxInFlight;
     final int sampleCount;
     final boolean didDrop;
     
-    public ImmutableSample() {
+    public ImmutableSampleWindow() {
         this.minRtt = Long.MAX_VALUE;
         this.maxInFlight = 0;
         this.sampleCount = 0;
         this.didDrop = false;
     }
     
-    public ImmutableSample(long minRtt, int maxInFlight, int sampleCount, boolean didDrop) {
+    public ImmutableSampleWindow(long minRtt, int maxInFlight, int sampleCount, boolean didDrop) {
         this.minRtt = minRtt;
         this.maxInFlight = maxInFlight;
         this.sampleCount = sampleCount;
         this.didDrop = didDrop;
     }
     
-    public ImmutableSample addSample(long rtt, int maxInFlight) {
-        return new ImmutableSample(Math.min(rtt, minRtt), Math.max(maxInFlight, this.maxInFlight), sampleCount+1, didDrop);
+    public ImmutableSampleWindow addSample(long rtt, int maxInFlight) {
+        return new ImmutableSampleWindow(Math.min(rtt, minRtt), Math.max(maxInFlight, this.maxInFlight), sampleCount+1, didDrop);
     }
     
-    public ImmutableSample addDroppedSample(int maxInFlight) {
-        return new ImmutableSample(minRtt, Math.max(maxInFlight, this.maxInFlight), sampleCount, true);
+    public ImmutableSampleWindow addDroppedSample(int maxInFlight) {
+        return new ImmutableSampleWindow(minRtt, Math.max(maxInFlight, this.maxInFlight), sampleCount, true);
     }
     
     @Override

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/AIMDLimitTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/AIMDLimitTest.java
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import com.netflix.concurrency.limits.limiter.ImmutableSample;
+import com.netflix.concurrency.limits.limiter.ImmutableSampleWindow;
 
 import junit.framework.Assert;
 
@@ -18,14 +18,14 @@ public class AIMDLimitTest {
     @Test
     public void increaseOnSuccess() {
         AIMDLimit limiter = AIMDLimit.newBuilder().initialLimit(10).build();
-        limiter.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(1), 10));
+        limiter.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(1), 10));
         Assert.assertEquals(11, limiter.getLimit());
     }
 
     @Test
     public void decreaseOnDrops() {
         AIMDLimit limiter = AIMDLimit.newBuilder().initialLimit(10).build();
-        limiter.update(new ImmutableSample().addDroppedSample(1));
+        limiter.update(new ImmutableSampleWindow().addDroppedSample(1));
         Assert.assertEquals(9, limiter.getLimit());
     }
 }

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import com.netflix.concurrency.limits.limiter.ImmutableSample;
+import com.netflix.concurrency.limits.limiter.ImmutableSampleWindow;
 
 import junit.framework.Assert;
 
@@ -28,27 +28,27 @@ public class VegasLimitTest {
     @Test
     public void increaseLimit() {
         VegasLimit limit = create();
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
         Assert.assertEquals(11, limit.getLimit());
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 11));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(10), 11));
         Assert.assertEquals(12, limit.getLimit());
     }
     
     @Test
     public void decreaseLimit() {
         VegasLimit limit = create();
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
         Assert.assertEquals(11, limit.getLimit());
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(50), 11));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(50), 11));
         Assert.assertEquals(10, limit.getLimit());
     }
     
     @Test
     public void noChangeIfWithinThresholds() {
         VegasLimit limit = create();
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(10), 10));
         Assert.assertEquals(11, limit.getLimit());
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(14), 14));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(14), 14));
         Assert.assertEquals(11, limit.getLimit());
     }
     
@@ -62,15 +62,15 @@ public class VegasLimitTest {
             .build();
         
         // Pick up first min-rtt
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 100));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(10), 100));
         Assert.assertEquals(100, limit.getLimit());
         
         // First decrease
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
         Assert.assertEquals(75, limit.getLimit());
 
         // Second decrease
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
         Assert.assertEquals(56, limit.getLimit());
     }
 
@@ -83,15 +83,15 @@ public class VegasLimitTest {
             .build();
         
         // Pick up first min-rtt
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(10), 100));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(10), 100));
         Assert.assertEquals(101, limit.getLimit());
         
         // First decrease
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
         Assert.assertEquals(50, limit.getLimit());
 
         // Second decrease
-        limit.update(new ImmutableSample().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
+        limit.update(new ImmutableSampleWindow().addSample(TimeUnit.MILLISECONDS.toNanos(20), 100));
         Assert.assertEquals(25, limit.getLimit());
     }
 }

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/DriverBuilder.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/DriverBuilder.java
@@ -1,0 +1,88 @@
+package com.netflix.concurrency.limits.grpc.server.example;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.apache.commons.math3.distribution.ExponentialDistribution;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.apache.commons.math3.distribution.UniformRealDistribution;
+
+public class DriverBuilder {
+    private static interface Segment {
+        long duration();
+        long nextDelay();
+        String name();
+    }
+    
+    static public DriverBuilder newBuilder() {
+        return new DriverBuilder();
+    }
+    
+    private List<DriverBuilder.Segment> segments = new ArrayList<>();
+    
+    public DriverBuilder normal(double mean, double sd, long duration, TimeUnit units) {
+        final NormalDistribution distribution = new NormalDistribution(mean, sd);
+        return add("normal(" + mean + ")", () -> (long)distribution.sample(), duration, units);
+    }
+    
+    public DriverBuilder uniform(double lower, double upper, long duration, TimeUnit units) {
+        final UniformRealDistribution distribution = new UniformRealDistribution(lower, upper);
+        return add("uniform(" + lower + "," + upper + ")", () -> (long)distribution.sample(), duration, units);
+    }
+    
+    public DriverBuilder exponential(double mean, long duration, TimeUnit units) {
+        final ExponentialDistribution distribution = new ExponentialDistribution(mean);
+        return add("exponential(" + mean + ")", () -> (long)distribution.sample(), duration, units);
+    }
+    
+    public DriverBuilder slience(long duration, TimeUnit units) {
+        return add("slience()", () -> units.toMillis(duration), duration, units);
+    }
+    
+    public DriverBuilder add(String name, Supplier<Long> delaySupplier, long duration, TimeUnit units) {
+        segments.add(new Segment() {
+            @Override
+            public long duration() {
+                return units.toNanos(duration);
+            }
+
+            @Override
+            public long nextDelay() {
+                return delaySupplier.get();
+            }
+
+            @Override
+            public String name() {
+                return name;
+            }
+        });
+        return this;
+    }
+
+    public void run(long runtime, TimeUnit units, Runnable action) {
+        long endTime = System.nanoTime() + units.toNanos(runtime);
+        while (true) {
+            for (DriverBuilder.Segment segment : segments) {
+                System.out.println(segment.name());
+                long segmentEndTime = System.nanoTime() + segment.duration();
+                while (true) {
+                    long currentTime = System.nanoTime();
+                    if (currentTime > endTime) {
+                        return;
+                    }
+                    
+                    if (currentTime > segmentEndTime) {
+                        break;
+                    }
+                    
+                    Uninterruptibles.sleepUninterruptibly(Math.max(0, segment.nextDelay()), TimeUnit.MILLISECONDS);
+                    action.run();
+                }
+            }
+        }
+    }
+}

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/Example.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/Example.java
@@ -61,6 +61,7 @@ public class Example {
     
     public static void main(String[] args) throws IOException {
         GradientLimit limit = GradientLimit.newBuilder()
+                .probeNoLoadRtt(30, 60)
                 .build();
         
         // Create a server
@@ -90,25 +91,26 @@ public class Example {
                 .usePlaintext(true)
                 .build();
 
-        while (true) {
-            Uninterruptibles.sleepUninterruptibly(6, TimeUnit.MILLISECONDS);
-            ClientCalls.asyncUnaryCall(channel.newCall(METHOD_DESCRIPTOR, CallOptions.DEFAULT.withWaitForReady()), "request",
-                new StreamObserver<String>() {
-                    @Override
-                    public void onNext(String value) {
-                    }
+        DriverBuilder.newBuilder()
+            .exponential(5, 5, TimeUnit.SECONDS)
+            .run(1, TimeUnit.HOURS, () -> {
+                ClientCalls.asyncUnaryCall(channel.newCall(METHOD_DESCRIPTOR, CallOptions.DEFAULT.withWaitForReady()), "request",
+                        new StreamObserver<String>() {
+                            @Override
+                            public void onNext(String value) {
+                            }
 
-                    @Override
-                    public void onError(Throwable t) {
-                        dropCount.incrementAndGet();
-                    }
+                            @Override
+                            public void onError(Throwable t) {
+                                dropCount.incrementAndGet();
+                            }
 
-                    @Override
-                    public void onCompleted() {
-                        successCount.incrementAndGet();
-                    }
-                
+                            @Override
+                            public void onCompleted() {
+                                successCount.incrementAndGet();
+                            }
+                        
+                    });
             });
-        }
     }
 }


### PR DESCRIPTION
- Fix race condition with updating the minimum sample window
- Fix bug in tracking the max inflight requests
- Put safeguards on probing for lower noload rtt 