### PR TITLE
feature: gradient noload rtt smoothing

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/Measurement.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/Measurement.java
@@ -11,14 +11,14 @@ public interface Measurement {
      * @param sample
      * @return True if internal state was updated
      */
-    boolean add(long sample);
+    boolean add(Number sample);
     
-    long update(Function<Long, Long> func);
+    Number update(Function<Number, Number> func);
     
     /**
      * @return Return the current value
      */
-    long get();
+    Number get();
     
     /**
      * Reset the internal state as if no samples were ever added

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/MinimumMeasurement.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/MinimumMeasurement.java
@@ -3,30 +3,30 @@ package com.netflix.concurrency.limits.limit;
 import java.util.function.Function;
 
 public class MinimumMeasurement implements Measurement {
-    private long value = 0;
+    private Double value = 0.0;
     
     @Override
-    public boolean add(long sample) {
-        if (value == 0 || sample < value) {
-            value = sample;
+    public boolean add(Number sample) {
+        if (value == 0.0 || sample.doubleValue() < value) {
+            value = sample.doubleValue();
             return true;
         }
         return false;
     }
 
     @Override
-    public long get() {
+    public Number get() {
         return value;
     }
 
     @Override
     public void reset() {
-        value = 0;
+        value = 0.0;
     }
 
     @Override
-    public long update(Function<Long, Long> func) {
-        value = func.apply(value);
+    public Number update(Function<Number, Number> func) {
+        value = func.apply(value).doubleValue();
         return value;
     }
 }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/SmoothingMinimumMeasurement.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/SmoothingMinimumMeasurement.java
@@ -1,0 +1,49 @@
+package com.netflix.concurrency.limits.limit;
+
+import java.util.function.Function;
+
+/**
+ * Measures the minimum value of a sample set but also adds a smoothing factor
+ */
+public class SmoothingMinimumMeasurement implements Measurement {
+    private Double value = 0.0;
+    private final double ratio;
+    
+    /**
+     * @param smoothing Factor applied to the new measurement using the formula
+     *          value = value * (1-smoothing) + newValue * smoothing
+     */
+    public SmoothingMinimumMeasurement(double smoothing) {
+        this.ratio = smoothing;
+    }
+    
+    @Override
+    public boolean add(Number sample) {
+        if (value == 0) {
+            value = sample.doubleValue();
+            return true;
+        } else if (sample.doubleValue() < value.doubleValue()) {
+            value = value * ratio + sample.doubleValue() * (1-ratio);
+            return true;
+        }
+        
+        return false;
+    }
+
+    @Override
+    public Number get() {
+        return value;
+    }
+
+    @Override
+    public void reset() {
+        value = 0.0;
+    }
+
+    @Override
+    public Number update(Function<Number, Number> func) {
+        double newValue = func.apply(value).doubleValue();
+        value = value * (1-ratio) + newValue * ratio;
+        return value;
+    }
+}


### PR DESCRIPTION
Reduce the impact of long GC's and huge spikes in latency by always smoothing updates to the limit.  Introduce smoothing to the noload RTT to keep that value more stable.