### PR TITLE
Add an optional timeout to BlockingLimiter

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractLimiter.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 public abstract class AbstractLimiter<ContextT> implements Limiter<ContextT> {
-    public abstract static class Builder<BuilderT extends Builder<BuilderT, ContextT>, ContextT> {
+    public abstract static class Builder<BuilderT extends Builder<BuilderT>> {
         private Limit limit = VegasLimit.newDefault();
         private Supplier<Long> clock = System::nanoTime;
         protected MetricRegistry registry = EmptyMetricRegistry.INSTANCE;
@@ -53,7 +53,7 @@ public abstract class AbstractLimiter<ContextT> implements Limiter<ContextT> {
     private final Limit limitAlgorithm;
     private volatile int limit;
 
-    protected AbstractLimiter(Builder<?, ContextT> builder) {
+    protected AbstractLimiter(Builder<?> builder) {
         this.clock = builder.clock;
         this.limitAlgorithm = builder.limit;
         this.limit = limitAlgorithm.getLimit();

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
 public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimiter<ContextT> {
     private static final String PARTITION_TAG_NAME = "partition";
 
-    public abstract static class Builder<BuilderT extends AbstractLimiter.Builder<BuilderT, ContextT>, ContextT> extends AbstractLimiter.Builder<BuilderT, ContextT> {
+    public abstract static class Builder<BuilderT extends AbstractLimiter.Builder<BuilderT>, ContextT> extends AbstractLimiter.Builder<BuilderT> {
         private List<Function<ContextT, String>> partitionResolvers = new ArrayList<>();
         private final Map<String, Partition> partitions = new LinkedHashMap<>();
 

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/SimpleLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/SimpleLimiter.java
@@ -18,9 +18,9 @@ package com.netflix.concurrency.limits.limiter;
 import java.util.Optional;
 
 public class SimpleLimiter<ContextT> extends AbstractLimiter<ContextT> {
-    public static class Builder<ContextT> extends AbstractLimiter.Builder<Builder<ContextT>, ContextT> {
-        public SimpleLimiter build() {
-            return new SimpleLimiter(this);
+    public static class Builder extends AbstractLimiter.Builder<Builder> {
+        public <ContextT> SimpleLimiter<ContextT> build() {
+            return new SimpleLimiter<>(this);
         }
 
         @Override
@@ -29,17 +29,17 @@ public class SimpleLimiter<ContextT> extends AbstractLimiter<ContextT> {
         }
     }
 
-    public static <ContextT> Builder<ContextT> newBuilder() {
-        return new Builder<ContextT>();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
-    public SimpleLimiter(AbstractLimiter.Builder<?, ContextT> builder) {
+    public SimpleLimiter(AbstractLimiter.Builder<?> builder) {
         super(builder);
     }
 
     @Override
     public Optional<Listener> acquire(ContextT context) {
-        if (getInflight() > getLimit()) {
+        if (getInflight() >= getLimit()) {
             return Optional.empty();
         }
         return Optional.of(createListener());

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/BlockingLimiterTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/BlockingLimiterTest.java
@@ -4,7 +4,10 @@ import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limit.SettableLimit;
 import org.junit.Test;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.LinkedList;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -13,6 +16,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class BlockingLimiterTest {
     @Test
@@ -49,5 +55,18 @@ public class BlockingLimiterTest {
         } finally {
             executorService.shutdown();
         }
+    }
+
+    @Test
+    public void testTimeout() {
+        Duration timeout = Duration.ofMillis(50);
+        SettableLimit limit = SettableLimit.startingAt(1);
+        BlockingLimiter<Void> limiter = BlockingLimiter.wrap(SimpleLimiter.newBuilder().limit(limit).build(), timeout);
+        limiter.acquire(null);
+        Instant before = Instant.now();
+        assertEquals(Optional.empty(), limiter.acquire(null));
+        Instant after = Instant.now();
+        Duration interval = Duration.between(before, after);
+        assertTrue(interval.compareTo(timeout) >= 0);
     }
 }


### PR DESCRIPTION
    Add an optional timeout to BlockingLimiter, and fix a bug in SimpleLimiter

    1. Fix a bug in SimpleLimiter - it fails if inflight > maxInflight, but
    should be >=.
    2. Improve the limiter builders; should not be generified until they
    need to be (e.g. SimpleLimiter should basically never care, because it
    doesn't use the context type much).
    3. Add an optional timeout to BlockingLimiter, so that users can e.g.
    block for up to a minute, and then fail.