### PR TITLE
feature: gradient2 fixes + server side delay

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/GradientLimit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/GradientLimit.java
@@ -46,7 +46,7 @@ public final class GradientLimit extends AbstractLimit {
         private int initialLimit = 50;
         private int minLimit = 1;
         private int maxConcurrency = 1000;
-        
+
         private double smoothing = 0.2;
         private Function<Integer, Integer> queueSize = SquareRootFunction.create(4);
         private MetricRegistry registry = EmptyMetricRegistry.INSTANCE;
@@ -272,9 +272,10 @@ public final class GradientLimit extends AbstractLimit {
         // Don't grow the limit if we are app limited
         } else if (inflight < estimatedLimit / 2) {
             return (int)estimatedLimit;
+        } else {
+            newLimit = estimatedLimit * gradient + queueSize;
         }
 
-        newLimit = estimatedLimit * gradient + queueSize;
         if (newLimit < estimatedLimit) {
             newLimit = Math.max(minLimit, estimatedLimit * (1-smoothing) + smoothing*(newLimit));
         }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/WindowedLimit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/WindowedLimit.java
@@ -30,7 +30,7 @@ public class WindowedLimit implements Limit {
     /**
      * Minimum observed samples to filter out sample windows with not enough significant samples
      */
-    private static final int DEFAULT_WINDOW_SIZE = 100;
+    private static final int DEFAULT_WINDOW_SIZE = 10;
 
     public static Builder newBuilder() {
         return new Builder();

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/ExpAvgMeasurementTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/ExpAvgMeasurementTest.java
@@ -1,17 +1,20 @@
 package com.netflix.concurrency.limits.limit;
 
 import com.netflix.concurrency.limits.limit.measurement.ExpAvgMeasurement;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ExpAvgMeasurementTest {
     @Test
-    public void test() {
-        ExpAvgMeasurement avg = new ExpAvgMeasurement(10);
+    public void testWarmup() {
+        ExpAvgMeasurement avg = new ExpAvgMeasurement(10, 10, Math::min);
 
         for (int i = 0; i < 10; i++) {
-            avg.add(1);
+            avg.add(i + 10);
+            Assert.assertEquals(10.0, avg.get().doubleValue(), 0.01);
         }
 
-        avg.add(10);
+        avg.add(100);
+        Assert.assertEquals(26.36, avg.get().doubleValue(), 0.01);
     }
 }

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/LatencyCollector.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/LatencyCollector.java
@@ -1,0 +1,37 @@
+package com.netflix.concurrency.limits.grpc.server.example;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+public class LatencyCollector implements Consumer<Long> {
+    private static class Metrics {
+        long count;
+        long total;
+
+        public Metrics() {
+            this(0, 0);
+        }
+
+        public Metrics(long count, long total) {
+            this.count = count;
+            this.total = total;
+        }
+
+        public long average() {
+            if (this.count == 0)
+                return 0;
+            return this.total / this.count;
+        }
+    }
+
+    AtomicReference<Metrics> foo = new AtomicReference<Metrics>(new Metrics());
+
+    @Override
+    public void accept(Long sample) {
+        foo.getAndUpdate(current -> new Metrics(current.count + 1, current.total + sample));
+    }
+
+    public long getAndReset() {
+        return foo.getAndSet(new Metrics()).average();
+    }
+}

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/PartitionedExample.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/PartitionedExample.java
@@ -1,0 +1,95 @@
+package com.netflix.concurrency.limits.grpc.server.example;
+
+import com.netflix.concurrency.limits.grpc.server.GrpcServerLimiterBuilder;
+import com.netflix.concurrency.limits.limit.Gradient2Limit;
+import com.netflix.concurrency.limits.limit.WindowedLimit;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PartitionedExample {
+
+    public static void main(String[] args) throws IOException, ExecutionException, InterruptedException {
+        final Gradient2Limit limit = Gradient2Limit.newBuilder()
+                .build();
+        
+        // Create a server
+        final TestServer server = TestServer.newBuilder()
+            .concurrency(2)
+            .lognormal(20, 1, TimeUnit.MINUTES)
+            .limiter(
+                new GrpcServerLimiterBuilder()
+                        .partitionByHeader(Driver.ID_HEADER)
+                        .partition("1", 1.0)
+                        .partition("2", 0.0)
+//                        .partition("3", 0.0)
+                        .partitionRejectDelay("2", 1000, TimeUnit.MILLISECONDS)
+//                        .partitionRejectDelay("3", 1000, TimeUnit.MILLISECONDS)
+                        .limit(WindowedLimit.newBuilder()
+                                .minWindowTime(1, TimeUnit.SECONDS)
+                                .windowSize(10)
+                                .build(limit))
+                .build()
+                )
+            .build();
+
+        final LatencyCollector latency = new LatencyCollector();
+
+        final Driver driver1 = Driver.newBuilder()
+                .id("1")
+                .exponentialRps(50, 60, TimeUnit.SECONDS)
+                .latencyAccumulator(latency)
+                .runtime(1, TimeUnit.HOURS)
+                .port(server.getPort())
+                .build();
+
+        final Driver driver2 = Driver.newBuilder()
+                .id("2")
+                .exponentialRps(50,  60, TimeUnit.SECONDS)
+                .exponentialRps(100, 60, TimeUnit.SECONDS)
+                .latencyAccumulator(latency)
+                .runtime(1, TimeUnit.HOURS)
+                .port(server.getPort())
+                .build();
+
+        final Driver driver3 = Driver.newBuilder()
+                .id("3")
+                .exponentialRps(50, 60, TimeUnit.SECONDS)
+                .latencyAccumulator(latency)
+                .runtime(1, TimeUnit.HOURS)
+                .port(server.getPort())
+                .build();
+
+        // Report progress
+        final AtomicInteger counter = new AtomicInteger(0);
+        System.out.println("iteration, limit, live, batch, live, batch, latency, shortRtt, longRtt");
+//        System.out.println("iteration, limit, 70%, 20%, 10%, 70%, 20%, 10%, latency, shortRtt, longRtt");
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+            System.out.println(MessageFormat.format(
+                    "{0,number,#}, {1,number,#}, {2,number,#}, {3,number,#}, {4,number,#}, {5,number,#}, {6,number,#}, {7,number,#}, {8,number,#}",
+                    counter.incrementAndGet(), 
+                    limit.getLimit(),
+                    driver1.getAndResetSuccessCount(),
+                    driver2.getAndResetSuccessCount(),
+//                    driver3.getAndResetSuccessCount(),
+                    driver1.getAndResetDropCount(),
+                    driver2.getAndResetDropCount(),
+//                    driver3.getAndResetDropCount(),
+                    TimeUnit.NANOSECONDS.toMillis(latency.getAndReset()),
+                    limit.getShortRtt(TimeUnit.MILLISECONDS),
+                    limit.getLongRtt(TimeUnit.MILLISECONDS)
+                    ))  ;
+        }, 1, 1, TimeUnit.SECONDS);
+
+        CompletableFuture.allOf(
+                  driver1.runAsync()
+                , driver2.runAsync()
+//                , driver3.runAsync()
+        ).get();
+    }
+}

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/TestServer.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/TestServer.java
@@ -28,8 +28,12 @@ import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.ServerCalls;
 import io.grpc.stub.ServerCalls.UnaryMethod;
 import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestServer {
+    private static final Logger LOG = LoggerFactory.getLogger(TestServer.class);
+
     public static final MethodDescriptor<String, String> METHOD_DESCRIPTOR = MethodDescriptor.<String, String>newBuilder()
             .setType(MethodType.UNARY)
             .setFullMethodName("service/method")
@@ -37,7 +41,7 @@ public class TestServer {
             .setResponseMarshaller(StringMarshaller.INSTANCE)
             .build();
 
-    private static interface Segment {
+    private interface Segment {
         long duration();
         long latency();
         String name();
@@ -125,8 +129,9 @@ public class TestServer {
             @Override
             public void invoke(String req, StreamObserver<String> observer) {
                 try {
+                    long delay = builder.segments.get(0).latency();
                     semaphore.acquire();
-                    TimeUnit.MILLISECONDS.sleep(builder.segments.get(0).latency());
+                    TimeUnit.MILLISECONDS.sleep(delay);
                     observer.onNext("response");
                     observer.onCompleted();
                 } catch (InterruptedException e) {


### PR DESCRIPTION
This PR contains two sets of changes that are related in that one improves the performance of the other.  

The first change fixes some issues with poor tracking of long and short term latency measurements in gradient2.  The fix is to track the minimum during a warmup period and then switch to exponential average.  This fixes the need to pick arbitrary operations for reseting the rtt measurements.  

The second change introduces a delay for partitions thereby allowing a server to ensure poorly behaved clients slow down instead of assuming the client will back off.  This is very useful for use cases where a service takes both live and batch traffic where excessive load from live traffic should be rejected immediately and retried on another server but batch traffic will be forced to slow down.  The main benefit of this is to prevent batch traffic from adversely affecting server performance. 
