### PR TITLE
Make sure that lock.wait in BlockingLimiter is never called with 0 timeout

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/BlockingLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/BlockingLimiter.java
@@ -72,8 +72,8 @@ public final class BlockingLimiter<ContextT> implements Limiter<ContextT> {
         final Instant deadline = Instant.now().plus(timeout);
         synchronized (lock) {
             while (true) {
-                final Instant now = Instant.now();
-                if (!now.isBefore(deadline)) {
+                long timeout = Duration.between(Instant.now(), deadline).toMillis();
+                if (timeout <= 0) {
                     return Optional.empty();
                 }
                 // Try to acquire a token and return immediately if successful
@@ -84,7 +84,7 @@ public final class BlockingLimiter<ContextT> implements Limiter<ContextT> {
                 
                 // We have reached the limit so block until a token is released
                 try {
-                    lock.wait(Duration.between(now, deadline).toMillis() + 1);
+                    lock.wait(timeout);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return Optional.empty();

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/BlockingLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/BlockingLimiter.java
@@ -84,7 +84,7 @@ public final class BlockingLimiter<ContextT> implements Limiter<ContextT> {
                 
                 // We have reached the limit so block until a token is released
                 try {
-                    lock.wait(Duration.between(now, deadline).toMillis());
+                    lock.wait(Duration.between(now, deadline).toMillis() + 1);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return Optional.empty();


### PR DESCRIPTION
Found this fun bug when trying to use this library with java 11 runtime. Turns out that in jdk 11 (or some prior version newer than 8) behaviour of Instant.now changed slightly such that it attempts to provide higher than millisecond resolution, previously `Instant.now()` would only ever return up to milliseconds but in 11 it returns up to microsecond resolution. Hence it can happen in java 11 that `now.isBefore(deadline)` is true but `Duration.between(now, deadline).toMillis()` rounds to 0 which results in a deadlock if no one ever calls `unblock` 