### PR TITLE
Fix Vegas log10 function

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/functions/Log10RootFunction.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/functions/Log10RootFunction.java
@@ -43,6 +43,6 @@ public final class Log10RootFunction implements Function<Integer, Integer> {
     
     @Override
     public Integer apply(Integer t) {
-        return t < 1000 ? lookup[t] : (int)Math.sqrt(t);
+        return t < 1000 ? lookup[t] : (int)Math.log10(t);
     }
 }

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
@@ -17,9 +17,15 @@ public class VegasLimitTest {
     }
     
     @Test
-    public void initialLimit() {
-        VegasLimit limit = create();
-        Assert.assertEquals(10, limit.getLimit());
+    public void largeLimitIncrease() {
+        VegasLimit limit = VegasLimit.newBuilder()
+                .initialLimit(10000)
+                .maxConcurrency(20000)
+                .build();
+        limit.onSample(0, TimeUnit.SECONDS.toNanos(10), 5000, false);
+        Assert.assertEquals(10000, limit.getLimit());
+        limit.onSample(0, TimeUnit.SECONDS.toNanos(10), 6000, false);
+        Assert.assertEquals(10024, limit.getLimit());
     }
 
     @Test

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/functions/Log10RootFunctionTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/functions/Log10RootFunctionTest.java
@@ -1,0 +1,26 @@
+package com.netflix.concurrency.limits.limit.functions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+public class Log10RootFunctionTest {
+    @Test
+    public void test0Index() {
+        Function<Integer, Integer> func = Log10RootFunction.create(0);
+        Assert.assertEquals(1, func.apply(0).intValue());
+    }
+
+    @Test
+    public void testInRange() {
+        Function<Integer, Integer> func = Log10RootFunction.create(0);
+        Assert.assertEquals(2, func.apply(100).intValue());
+    }
+
+    @Test
+    public void testOutofLookupRange() {
+        Function<Integer, Integer> func = Log10RootFunction.create(0);
+        Assert.assertEquals(4, func.apply(10000).intValue());
+    }
+}


### PR DESCRIPTION
Hi!

I've noticed an inconsistency in the `log10` function where `Log10RootFunction` uses `sqrt` instead of `log10`. As far as I understand from the javadoc, this is not by design. 