### PR TITLE
WindowedLimit builder precondition fix and small cleanup:

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/ImmutableSampleWindow.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/ImmutableSampleWindow.java
@@ -55,7 +55,7 @@ class ImmutableSampleWindow {
         return minRtt;
     }
 
-    public long getAverateRttNanos() {
+    public long getAverageRttNanos() {
         return sampleCount == 0 ? 0 : sum / sampleCount;
     }
     
@@ -75,7 +75,7 @@ class ImmutableSampleWindow {
     public String toString() {
         return "ImmutableSampleWindow ["
                 + "minRtt=" + TimeUnit.NANOSECONDS.toMicros(minRtt) / 1000.0 
-                + ", avgRtt=" + TimeUnit.NANOSECONDS.toMicros(getAverateRttNanos()) / 1000.0
+                + ", avgRtt=" + TimeUnit.NANOSECONDS.toMicros(getAverageRttNanos()) / 1000.0
                 + ", maxInFlight=" + maxInFlight 
                 + ", sampleCount=" + sampleCount 
                 + ", didDrop=" + didDrop + "]";

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/WindowedLimit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/WindowedLimit.java
@@ -55,7 +55,7 @@ public class WindowedLimit implements Limit {
          * Maximum window duration for sampling a new minRtt
          */
         public Builder maxWindowTime(long maxWindowTime, TimeUnit units) {
-            Preconditions.checkArgument(maxWindowTime >= units.toMillis(100), "minWindowTime must be >= 100 ms");
+            Preconditions.checkArgument(units.toMillis(maxWindowTime) >= 100, "maxWindowTime must be >= 100 ms");
             this.maxWindowTime = units.toNanos(maxWindowTime);
             return this;
         }
@@ -137,7 +137,7 @@ public class WindowedLimit implements Limit {
                         sample.set(new ImmutableSampleWindow());
 
                         nextUpdateTime = endTime + Math.min(Math.max(current.getCandidateRttNanos() * 2, minWindowTime), maxWindowTime);
-                        delegate.onSample(startTime, current.getAverateRttNanos(), current.getMaxInFlight(), current.didDrop());
+                        delegate.onSample(startTime, current.getAverageRttNanos(), current.getMaxInFlight(), current.didDrop());
                     }
                 }
             }


### PR DESCRIPTION
- precondition for `maxWindowTime()` now allows to pass timeunits bigger than milliseconds
- distinguish builder error messages between `maxWindowTime` and `minWindowTime`
- typo in `ImmutableSampleWindow`: averaTe -> averaGe