### PR TITLE
Improve GRPC client call rejection

### DIFF
--- a/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/client/ConcurrencyLimitClientInterceptor.java
+++ b/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/client/ConcurrencyLimitClientInterceptor.java
@@ -103,27 +103,31 @@ public class ConcurrencyLimitClientInterceptor implements ClientInterceptor {
                         }
                 )
                 .orElseGet(() -> new ClientCall<ReqT, RespT>() {
-                            @Override
-                            public void start(io.grpc.ClientCall.Listener<RespT> responseListener, Metadata headers) {
-                                responseListener.onClose(LIMIT_EXCEEDED_STATUS, new Metadata());
-                            }
 
-                            @Override
-                            public void request(int numMessages) {
-                            }
+                        private Listener<RespT> responseListener;
 
-                            @Override
-                            public void cancel(String message, Throwable cause) {
-                            }
-
-                            @Override
-                            public void halfClose() {
-                            }
-
-                            @Override
-                            public void sendMessage(ReqT message) {
-                            }
+                        @Override
+                        public void start(io.grpc.ClientCall.Listener<RespT> responseListener, Metadata headers) {
+                            this.responseListener = responseListener;
                         }
+
+                        @Override
+                        public void request(int numMessages) {
+                        }
+
+                        @Override
+                        public void cancel(String message, Throwable cause) {
+                        }
+
+                        @Override
+                        public void halfClose() {
+                            responseListener.onClose(LIMIT_EXCEEDED_STATUS, new Metadata());
+                        }
+
+                        @Override
+                        public void sendMessage(ReqT message) {
+                        }
+                    }
                 );
     }
 }


### PR DESCRIPTION
Close rejected requests in halfClose() to allow for the entire call sequence to complete since previously invoked interceptors may need to capture it.