### PR TITLE
Improved stability

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/WindowedLimit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/WindowedLimit.java
@@ -141,15 +141,14 @@ public class WindowedLimit implements Limit {
             sample.updateAndGet(current -> current.addSample(rtt, inflight));
         }
 
-        if (startTime + rtt > nextUpdateTime) {
+        if (endTime > nextUpdateTime) {
             synchronized (lock) {
                 // Double check under the lock
                 if (endTime > nextUpdateTime) {
-                    SampleWindow current = sample.get();
-                    if (isWindowReady(current)) {
-                        sample.set(sampleWindowFactory.newInstance());
+                    SampleWindow current = sample.getAndSet(sampleWindowFactory.newInstance());
+                    nextUpdateTime = endTime + Math.min(Math.max(current.getCandidateRttNanos() * 2, minWindowTime), maxWindowTime);
 
-                        nextUpdateTime = endTime + Math.min(Math.max(current.getCandidateRttNanos() * 2, minWindowTime), maxWindowTime);
+                    if (isWindowReady(current)) {
                         delegate.onSample(startTime, current.getTrackedRttNanos(), current.getMaxInFlight(), current.didDrop());
                     }
                 }
@@ -158,7 +157,7 @@ public class WindowedLimit implements Limit {
     }
 
     private boolean isWindowReady(SampleWindow sample) {
-        return sample.getCandidateRttNanos() < Long.MAX_VALUE && sample.getSampleCount() > windowSize;
+        return sample.getCandidateRttNanos() < Long.MAX_VALUE && sample.getSampleCount() >= windowSize;
     }
 
     @Override

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/Example.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/Example.java
@@ -15,10 +15,8 @@ import java.util.function.Consumer;
 
 public class Example {
     public static void main(String[] args) throws IOException {
-        final Gradient2Limit limit = Gradient2Limit.newBuilder()
-                .longWindow(100)
-                .build();
-        
+        final Gradient2Limit limit = Gradient2Limit.newBuilder().build();
+
         // Create a server
         final TestServer server = TestServer.newBuilder()
             .concurrency(2)
@@ -36,10 +34,10 @@ public class Example {
         final LatencyCollector latency = new LatencyCollector();
 
         final Driver driver = Driver.newBuilder()
-            .exponentialRps(50,  400, TimeUnit.SECONDS)
-            .exponentialRps(100, 400, TimeUnit.SECONDS)
-            .exponentialRps(200, 400, TimeUnit.SECONDS)
-            .exponentialRps(100, 400, TimeUnit.SECONDS)
+            .exponentialRps(50,  100, TimeUnit.SECONDS)
+            .exponentialRps(90,  100, TimeUnit.SECONDS)
+            .exponentialRps(200, 100, TimeUnit.SECONDS)
+            .exponentialRps(100, 100, TimeUnit.SECONDS)
             .latencyAccumulator(latency)
             .runtime(1, TimeUnit.HOURS)
             .port(server.getPort())
@@ -49,15 +47,19 @@ public class Example {
         final AtomicInteger counter = new AtomicInteger(0);
         System.out.println("iteration, limit, success, drop, latency, shortRtt, longRtt");
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
-            System.out.println(MessageFormat.format("{0,number,#}, {1,number,#}, {2,number,#}, {3,number,#}, {4,number,#}, {5,number,#}, {6,number,#}",
-                    counter.incrementAndGet(), 
-                    limit.getLimit(), 
-                    driver.getAndResetSuccessCount(),
-                    driver.getAndResetDropCount(),
-                    TimeUnit.NANOSECONDS.toMillis(latency.getAndReset()),
-                    limit.getShortRtt(TimeUnit.MILLISECONDS),
-                    limit.getLongRtt(TimeUnit.MILLISECONDS)
-                    ))  ;
+            try {
+                System.out.println(MessageFormat.format("{0,number,#}, {1,number,#}, {2,number,#}, {3,number,#}, {4,number,#}, {5,number,#}, {6,number,#}",
+                        counter.incrementAndGet(),
+                        limit.getLimit(),
+                        driver.getAndResetSuccessCount(),
+                        driver.getAndResetDropCount(),
+                        TimeUnit.NANOSECONDS.toMillis(latency.getAndReset()),
+                        limit.getLastRtt(TimeUnit.MILLISECONDS),
+                        limit.getRttNoLoad(TimeUnit.MILLISECONDS)
+                ));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }, 1, 1, TimeUnit.SECONDS);
         
         // Create a client

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/PartitionedExample.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/example/PartitionedExample.java
@@ -81,8 +81,8 @@ public class PartitionedExample {
                     driver2.getAndResetDropCount(),
 //                    driver3.getAndResetDropCount(),
                     TimeUnit.NANOSECONDS.toMillis(latency.getAndReset()),
-                    limit.getShortRtt(TimeUnit.MILLISECONDS),
-                    limit.getLongRtt(TimeUnit.MILLISECONDS)
+                    limit.getLastRtt(TimeUnit.MILLISECONDS),
+                    limit.getRttNoLoad(TimeUnit.MILLISECONDS)
                     ))  ;
         }, 1, 1, TimeUnit.SECONDS);
 


### PR DESCRIPTION
- Introduce tolerance to gradient2 for more permissive limit growth
- Completely drop windowed samples that are not ready.  For low RPS services these sample could eventually contain a very low RTT candidate (for example, if all the calls were healthchecks)