### PR TITLE
Include error latency

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/WindowedLimit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/WindowedLimit.java
@@ -135,11 +135,7 @@ public class WindowedLimit implements Limit {
             return;
         }
 
-        if (didDrop) {
-            sample.updateAndGet(current -> current.addDroppedSample(inflight));
-        } else {
-            sample.updateAndGet(current -> current.addSample(rtt, inflight));
-        }
+        sample.updateAndGet(current -> current.addSample(rtt, inflight, didDrop));
 
         if (endTime > nextUpdateTime) {
             synchronized (lock) {

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/window/ImmutableAverageSampleWindow.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/window/ImmutableAverageSampleWindow.java
@@ -41,19 +41,14 @@ class ImmutableAverageSampleWindow implements SampleWindow {
     }
 
     @Override
-    public ImmutableAverageSampleWindow addSample(long rtt, int inflight) {
+    public ImmutableAverageSampleWindow addSample(long rtt, int inflight, boolean didDrop) {
         return new ImmutableAverageSampleWindow(
                 Math.min(rtt, minRtt),
                 sum + rtt,
                 Math.max(inflight, this.maxInFlight),
                 sampleCount + 1,
-                didDrop
+                this.didDrop || didDrop
         );
-    }
-
-    @Override
-    public ImmutableAverageSampleWindow addDroppedSample(int inflight) {
-        return new ImmutableAverageSampleWindow(minRtt, sum, Math.max(inflight, this.maxInFlight), sampleCount, true);
     }
 
     @Override

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/window/ImmutablePercentileSampleWindow.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/window/ImmutablePercentileSampleWindow.java
@@ -50,7 +50,7 @@ class ImmutablePercentileSampleWindow implements SampleWindow {
     }
 
     @Override
-    public ImmutablePercentileSampleWindow addSample(long rtt, int inflight) {
+    public ImmutablePercentileSampleWindow addSample(long rtt, int inflight, boolean didDrop) {
         // TODO: very naive
         // full copy in order to fulfill side-effect-free requirement of AtomicReference::updateAndGet
         List<Long> newObservedRtts = new ArrayList<>(observedRtts);
@@ -58,19 +58,8 @@ class ImmutablePercentileSampleWindow implements SampleWindow {
         return new ImmutablePercentileSampleWindow(
                 Math.min(minRtt, rtt),
                 Math.max(inflight, this.maxInFlight),
-                didDrop,
+                this.didDrop || didDrop,
                 newObservedRtts,
-                percentile
-        );
-    }
-
-    @Override
-    public ImmutablePercentileSampleWindow addDroppedSample(int inflight) {
-        return new ImmutablePercentileSampleWindow(
-                minRtt,
-                Math.max(inflight, this.maxInFlight),
-                true,
-                observedRtts,
                 percentile
         );
     }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/window/SampleWindow.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/window/SampleWindow.java
@@ -21,9 +21,7 @@ package com.netflix.concurrency.limits.limit.window;
  * @see com.netflix.concurrency.limits.limit.WindowedLimit
  */
 public interface SampleWindow {
-    SampleWindow addSample(long rtt, int inflight);
-
-    SampleWindow addDroppedSample(int inflight);
+    SampleWindow addSample(long rtt, int inflight, boolean dropped);
 
     long getCandidateRttNanos();
 

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/window/ImmutableAverageSampleWindowTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/window/ImmutableAverageSampleWindowTest.java
@@ -26,19 +26,19 @@ public class ImmutableAverageSampleWindowTest {
     @Test
     public void calculateAverage() {
         ImmutableAverageSampleWindow window = new ImmutableAverageSampleWindow();
-        window = window.addSample(bigRtt, 1);
-        window = window.addSample(moderateRtt, 1);
-        window = window.addSample(lowRtt, 1);
+        window = window.addSample(bigRtt, 1, false);
+        window = window.addSample(moderateRtt, 1, false);
+        window = window.addSample(lowRtt, 1, false);
         Assert.assertEquals((bigRtt + moderateRtt + lowRtt) / 3, window.getTrackedRttNanos());
     }
 
     @Test
     public void droppedSampleShouldNotChangeTrackedAverage() {
         ImmutableAverageSampleWindow window = new ImmutableAverageSampleWindow();
-        window = window.addSample(bigRtt, 1);
-        window = window.addSample(moderateRtt, 1);
-        window = window.addSample(lowRtt, 1);
-        window = window.addDroppedSample(1);
-        Assert.assertEquals((bigRtt + moderateRtt + lowRtt) / 3, window.getTrackedRttNanos());
+        window = window.addSample(bigRtt, 1, false);
+        window = window.addSample(moderateRtt, 1, false);
+        window = window.addSample(lowRtt, 1, false);
+        window = window.addSample(bigRtt, 1, true);
+        Assert.assertEquals((bigRtt + moderateRtt + lowRtt + bigRtt) / 4, window.getTrackedRttNanos());
     }
 }

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/window/ImmutablePercentileSampleWindowTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/window/ImmutablePercentileSampleWindowTest.java
@@ -26,29 +26,29 @@ public class ImmutablePercentileSampleWindowTest {
     @Test
     public void calculateP50() {
         ImmutablePercentileSampleWindow window = new ImmutablePercentileSampleWindow(0.5);
-        window = window.addSample(slowestRtt, 1);
-        window = window.addSample(moderateRtt, 1);
-        window = window.addSample(fastestRtt, 1);
+        window = window.addSample(slowestRtt, 1, false);
+        window = window.addSample(moderateRtt, 1, false);
+        window = window.addSample(fastestRtt, 1, false);
         Assert.assertEquals(moderateRtt, window.getTrackedRttNanos());
     }
 
     @Test
     public void droppedSampleShouldNotChangeTrackedRtt() {
         ImmutablePercentileSampleWindow window = new ImmutablePercentileSampleWindow(0.5);
-        window = window.addSample(slowestRtt, 1);
-        window = window.addSample(moderateRtt, 1);
-        window = window.addSample(fastestRtt, 1);
-        window = window.addDroppedSample(1);
+        window = window.addSample(slowestRtt, 1, false);
+        window = window.addSample(moderateRtt, 1, false);
+        window = window.addSample(fastestRtt, 1, false);
+        window = window.addSample(slowestRtt, 1, true);
         Assert.assertEquals(moderateRtt, window.getTrackedRttNanos());
     }
     
     @Test
     public void p999ReturnsSlowestObservedRtt() {
         ImmutablePercentileSampleWindow window = new ImmutablePercentileSampleWindow(0.999);
-        window = window.addSample(slowestRtt, 1);
-        window = window.addSample(moderateRtt, 1);
-        window = window.addSample(fastestRtt, 1);
-        window = window.addDroppedSample(1);
+        window = window.addSample(slowestRtt, 1, false);
+        window = window.addSample(moderateRtt, 1, false);
+        window = window.addSample(fastestRtt, 1, false);
+        window = window.addSample(slowestRtt, 1, true);
         Assert.assertEquals(slowestRtt, window.getTrackedRttNanos());
     }
 }

--- a/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/server/ConcurrencyLimitServerInterceptor.java
+++ b/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/server/ConcurrencyLimitServerInterceptor.java
@@ -164,10 +164,14 @@ public class ConcurrencyLimitServerInterceptor implements ServerInterceptor {
                                                 super.close(status, trailers);
                                             } finally {
                                                 safeComplete(() -> {
-                                                    if (status.isOk()) {
-                                                        listener.onSuccess();
-                                                    } else {
-                                                        listener.onIgnore();
+                                                    switch (status.getCode()) {
+                                                        case CANCELLED:
+                                                        case DEADLINE_EXCEEDED:
+                                                            listener.onDropped();
+                                                            break;
+                                                        default:
+                                                            listener.onSuccess();
+                                                            break;
                                                     }
                                                 });
                                             }

--- a/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/server/GrpcServerLimiterBuilder.java
+++ b/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/server/GrpcServerLimiterBuilder.java
@@ -15,9 +15,7 @@
  */
 package com.netflix.concurrency.limits.grpc.server;
 
-import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limiter.AbstractPartitionedLimiter;
-import com.netflix.concurrency.limits.limiter.SimpleLimiter;
 import io.grpc.Attributes;
 import io.grpc.Metadata;
 

--- a/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/ConcurrencyLimitServerInterceptorTest.java
+++ b/concurrency-limits-grpc/src/test/java/com/netflix/concurrency/limits/grpc/server/ConcurrencyLimitServerInterceptorTest.java
@@ -105,7 +105,6 @@ public class ConcurrencyLimitServerInterceptorTest {
         }
         // Verify
         Mockito.verify(limiter, Mockito.times(1)).acquire(Mockito.isA(GrpcServerRequestContext.class));
-        Mockito.verify(listener.getResult().get(), Mockito.timeout(1000).times(1)).onIgnore();
     }
 
     @Test


### PR DESCRIPTION
Currently, we only track latency measurements for successful responses.  This means that limit is not properly updated when all requests time out.