### PR TITLE
executor: Add UncheckedTimeoutException

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/executors/BlockingAdaptiveExecutor.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/executors/BlockingAdaptiveExecutor.java
@@ -17,11 +17,17 @@ package com.netflix.concurrency.limits.executors;
 
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.Limiter.Listener;
+import com.netflix.concurrency.limits.MetricRegistry;
+import com.netflix.concurrency.limits.internal.EmptyMetricRegistry;
+import com.netflix.concurrency.limits.limit.AIMDLimit;
 import com.netflix.concurrency.limits.limiter.BlockingLimiter;
+import com.netflix.concurrency.limits.limiter.SimpleLimiter;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * {@link Executor} which uses a {@link Limiter} to determine the size of the thread pool.
@@ -30,18 +36,84 @@ import java.util.concurrent.RejectedExecutionException;
  * 
  * Operations submitted to this executor should be homogeneous and have similar
  * long term latency characteristics.  RTT samples will only be taken from successful 
- * operations.  The {@link Runnable} should throw a {@link RejectedExecutionException} if 
+ * operations.  The {@link Runnable} should throw a {@link UncheckedTimeoutException} if
  * a request timed out or some external limit was reached.  All other exceptions will be
  * ignored.
  */
 public final class BlockingAdaptiveExecutor implements Executor {
+    public static class Builder {
+        private static AtomicInteger idCounter = new AtomicInteger();
+
+        private MetricRegistry metricRegistry = EmptyMetricRegistry.INSTANCE;
+        private Executor executor;
+        private Limiter<Void> limiter;
+        private String name;
+
+        public Builder metricRegistry(MetricRegistry metricRegistry) {
+            this.metricRegistry = metricRegistry;
+            return this;
+        }
+
+        public Builder executor(Executor executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        public Builder limiter(Limiter<Void> limiter) {
+            this.limiter = limiter;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public BlockingAdaptiveExecutor build() {
+            if (name == null) {
+                name = "unnamed-" + idCounter.incrementAndGet();
+            }
+
+            if (executor == null) {
+                executor = Executors.newCachedThreadPool(new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        thread.setDaemon(true);
+                        return thread;
+                    }
+                });
+            }
+
+            if (limiter == null) {
+                limiter = SimpleLimiter.newBuilder()
+                        .metricRegistry(metricRegistry)
+                        .limit(AIMDLimit.newBuilder().build())
+                        .build();
+            }
+
+            return new BlockingAdaptiveExecutor(this);
+        }
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
     private final Limiter<Void> limiter;
     private final Executor executor;
 
+    private BlockingAdaptiveExecutor(Builder builder) {
+        this.limiter = builder.limiter;
+        this.executor = builder.executor;
+    }
+
+    @Deprecated
     public BlockingAdaptiveExecutor(Limiter<Void> limiter) {
         this(limiter, Executors.newCachedThreadPool());
     }
 
+    @Deprecated
     public BlockingAdaptiveExecutor(Limiter<Void> limiter, Executor executor) {
         this.limiter = BlockingLimiter.wrap(limiter);
         this.executor = executor;
@@ -49,16 +121,26 @@ public final class BlockingAdaptiveExecutor implements Executor {
 
     @Override
     public void execute(Runnable command) {
-        Listener token = limiter.acquire(null).orElseThrow(() -> new RejectedExecutionException());
-        executor.execute(() -> {
-            try {
-                command.run();
-                token.onSuccess();
-            } catch (RejectedExecutionException e) {
-                token.onDropped();
-            } catch (Exception e) {
-                token.onIgnore();
-            }
-        });
+        Listener listener = limiter.acquire(null).orElseThrow(() -> new RejectedExecutionException());
+        try {
+            executor.execute(() -> {
+                try {
+                    command.run();
+                    listener.onSuccess();
+                } catch (UncheckedTimeoutException e) {
+                    listener.onDropped();
+                } catch (RejectedExecutionException e) {
+                    // TODO: Remove support for RejectedExecutionException here.
+                    listener.onDropped();
+                } catch (Exception e) {
+                    // We have no idea what caused the exception.  It could be an NPE thrown immediately on the client
+                    // or some remote call failure.  The only sane thing to do here is just ignore this request
+                    listener.onIgnore();
+                }
+            });
+        } catch (Exception e) {
+            listener.onIgnore();
+            throw e;
+        }
     }
 }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/executors/UncheckedTimeoutException.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/executors/UncheckedTimeoutException.java
@@ -1,0 +1,19 @@
+package com.netflix.concurrency.limits.executors;
+
+public class UncheckedTimeoutException extends RuntimeException {
+    private static final long serialVersionUID = 0;
+
+    public UncheckedTimeoutException() {}
+
+    public UncheckedTimeoutException(String message) {
+        super(message);
+    }
+
+    public UncheckedTimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    public UncheckedTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/executor/BlockingAdaptiveExecutorSimulation.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/executor/BlockingAdaptiveExecutorSimulation.java
@@ -24,7 +24,7 @@ public class BlockingAdaptiveExecutorSimulation {
     @Test
     public void test() {
         Limiter<Void> limiter = SimpleLimiter.newBuilder().limit(AIMDLimit.newBuilder().initialLimit(10).build()).build();
-        Executor executor = new BlockingAdaptiveExecutor(limiter);
+        Executor executor = BlockingAdaptiveExecutor.newBuilder().limiter(limiter).build();
         
         run(10000, 20, executor, randomLatency(50, 150));
     }
@@ -36,7 +36,7 @@ public class BlockingAdaptiveExecutorSimulation {
                     .initialLimit(100)
                     .build()))
                 .build();
-        Executor executor = new BlockingAdaptiveExecutor(limiter);
+        Executor executor = BlockingAdaptiveExecutor.newBuilder().limiter(limiter).build();
         run(10000, 50, executor, randomLatency(50, 150));
     }
     
@@ -47,7 +47,7 @@ public class BlockingAdaptiveExecutorSimulation {
                     .initialLimit(100)
                     .build()))
                 .build();
-        Executor executor = new BlockingAdaptiveExecutor(limiter);
+        Executor executor = BlockingAdaptiveExecutor.newBuilder().limiter(limiter).build();
         run(100000, 50, executor, randomLatency(50, 150));
     }
     
@@ -80,13 +80,5 @@ public class BlockingAdaptiveExecutorSimulation {
     
     public Supplier<Long> randomLatency(int min, int max) {
         return () -> min + ThreadLocalRandom.current().nextLong(max - min);
-    }
-    
-    public void sleepNoThrow(long timeout, TimeUnit units) {
-        try {
-            units.sleep(timeout);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
     }
 }


### PR DESCRIPTION
Provide an UncheckedTimeoutException for runnables to indicate timeouts to BlockingAdaptiveExecutor.