### PR TITLE
Ignore cancelled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 sudo: false
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"

--- a/concurrency-limits-grpc/build.gradle
+++ b/concurrency-limits-grpc/build.gradle
@@ -7,7 +7,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     compile project(":concurrency-limits-core")
 
-    compile "io.grpc:grpc-core:1.9.0"
+    compileOnly "io.grpc:grpc-core:1.9.0"
     
     testCompile project(":concurrency-limits-spectator")
 

--- a/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/server/ConcurrencyLimitServerInterceptor.java
+++ b/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/server/ConcurrencyLimitServerInterceptor.java
@@ -160,7 +160,6 @@ public class ConcurrencyLimitServerInterceptor implements ServerInterceptor {
                                         } finally {
                                             safeComplete(() -> {
                                                 switch (status.getCode()) {
-                                                    case CANCELLED:
                                                     case DEADLINE_EXCEEDED:
                                                         listener.onDropped();
                                                         break;


### PR DESCRIPTION
- Stop treating cancelled as timeouts (for gRPC) as poor client behavior can adversely affect the server concurrency limiter
- For `gradient` make the backoff ratio for drops configurable and change the default to 0.9 (from 0.5) since the current default can result in overly aggressive load shedding.