### PR TITLE
ISSUE-159 VegasLimit for batch processing

### DIFF
--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
@@ -3,6 +3,9 @@ package com.netflix.concurrency.limits.limit;
 import junit.framework.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class VegasLimitTest {
@@ -12,6 +15,17 @@ public class VegasLimitTest {
                 .beta(6)
                 .smoothing(1.0)
                 .initialLimit(10)
+                .maxConcurrency(20)
+                .build();
+    }
+
+    public static VegasLimit create(double bufferFactor) {
+        return VegasLimit.newBuilder()
+                .alpha(3)
+                .beta(6)
+                .smoothing(1.0)
+                .initialLimit(10)
+                .bufferFactor(bufferFactor)
                 .maxConcurrency(20)
                 .build();
     }
@@ -45,6 +59,15 @@ public class VegasLimitTest {
         limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(50), 11, false);
         Assert.assertEquals(9, limit.getLimit());
     }
+
+    @Test
+    public void decreaseLimitWithBufferFactor() {
+        VegasLimit limit = create(1.0);
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(10), 10, false);
+        Assert.assertEquals(10, limit.getLimit());
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(50), 11, false);
+        Assert.assertEquals(10, limit.getLimit());
+    }
     
     @Test
     public void noChangeIfWithinThresholds() {
@@ -54,7 +77,16 @@ public class VegasLimitTest {
         limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(14), 14, false);
         Assert.assertEquals(10, limit.getLimit());
     }
-    
+
+    @Test
+    public void noChangeIfWithinThresholdsWithBuffer() {
+        VegasLimit limit = create(1.0);
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(10), 10, false);
+        Assert.assertEquals(10, limit.getLimit());
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(5), 14, false);
+        Assert.assertEquals(10, limit.getLimit());
+    }
+
     @Test
     public void decreaseSmoothing() {
         VegasLimit limit = VegasLimit.newBuilder()
@@ -96,5 +128,16 @@ public class VegasLimitTest {
         // Second decrease
         limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(20), 100, false);
         Assert.assertEquals(25, limit.getLimit());
+    }
+
+    @Test
+    public void pauseUpdateWhenProbe() {
+        VegasLimit limit = create(1.0);
+        List<Integer> limits = new ArrayList<>();
+        limit.notifyOnChange(v -> limits.add(v));
+        for (int i = 0; i < 600; ++i) {
+            limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(10), 100, false);
+        }
+        Assert.assertEquals(Arrays.asList(16,20,10), limits);
     }
 }


### PR DESCRIPTION
**Background**
At Uber, We use kafka producer to produce message to broker, we saw two problems could casue kafka producer overload while running the system.  
1. Surge of messages rate.
2. Broker degradation
and when kafka producer overloaded, messages accumulated in buffer, then it casues high message delivery latency, saturation of garbage-collector, and drop of throughput.
We think load shedding is the right way to deal with overload, however, existing concurrency limit algorithm is not perfectly fit for batching system, such as kafka producer.

**Abstraction**
As a batching system, kafka producer comes with a sending buffer. while sending message, clients put messages into the buffer. 
And there are one or more sender threads keeps fetching message from the queue and send them to broker. latency is evaluated after client received ack from broker.
So in the system, latnecy has two components. 
 - message buffer time
 - request roundtrip time
concretely, there is equation: 
           1:      observed-latency = buffer-time + roundtrip-latency
in practice, when not overload, there is following relasionship              
           2:      0 < buffer-time < BF * roundtrip-latency ( BF standfor bufferFactory = 1 / num-inflight-requests) 
with equation 1 and relasionship 2, there is  
           3:      roundtrip-latency < observed-latency < (1 + BF) * roundtrip-latency

The problem of VegasLimit is, it use rtt_noload as boundary to detect saturation.
however, for a batching system, it could easily cause over shedding, so we are proposal a little enhancement to make VegasLimit perfectly fit for batching system


**Solution**
Here is high level solution
1. Introduce bufferFactor to represent portion of buffer-time in observed-latency. 
2. Consider bufferFactor while caculating queue size to avoid over shedding
3. Consider bufferFactor while reseting probe to avoid limit inflation

with bufferFactor to represent portion of buffer-time in observed-latency, we propose a new equation to estimiate queue size

        queueSize = (int) Math.ceil(estimatedLimit * (1 - (double)rtt_noload * (bufferFactor + 1) / rtt));

it suggests no queue, when 0 < rtt < rtt_noload * (bufferFactor + 1)

Unfortunatly, we found in practice, the change prevented over shedding, but also causes another problem - limit inflation.
limit inflation means concurrent limit gradually increase as time elapse.
The reason is when probe, we have 
            
            rtt_noload = rtt

when sytem under load, rtt are actually in the range of [rtt_noload, (bufferFactor + 1) * rtt_noload]
as a result, if when probe, rtt is at the higher end, it could casue both rtt_noload and estimatedLimit inflate.

We solved the problem in two steps
1. when probe, update estimatedLimit with following equation

             estimatedLimit = Math.max(initialLimit, Math.ceil(estimatedLimit / (bufferFactor + 1))

the change shinks concurrency limit to bare size (no buffer), so in case system is under load, it should start rejecting requets and concurrency start dropping.
evently when concurrency dropped to estimatedLimit, observed rtt should be equals to rtt_noload, and limit inflation can be solved.


2. Pause updating of estimatedLimit for extra amount of time, to allow rtt dropped to rtt_noload
            
             pauseUpdateTime = rtt * (1 + bufferFactor / (1 + bufferFactor))

It takes time to have concurrency dropped to updated estimatedLimit, and during the time, updating of estimatedLimit should be paused. 
other wise estimatedLimit could increase during the time, and miss the opportunity to observe rtt_noload.
The time to wait can be estimated with above equation.