### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url = 'https://plugins.gradle.org/m2'
+        }
     }
     dependencies {
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.2'


### PR DESCRIPTION
This replaces jcenter with maven central to avoid broken builds in the future

