### PR TITLE
don't drop by half periodically.

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/AIMDLimit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/AIMDLimit.java
@@ -99,10 +99,6 @@ public final class AIMDLimit extends AbstractLimit {
             currentLimit =  currentLimit + 1;
         }
 
-        if (currentLimit >= maxLimit) {
-            currentLimit = currentLimit / 2;
-        }
-
         return Math.min(maxLimit, Math.max(minLimit, currentLimit));
     }
 

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/AIMDLimitTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/AIMDLimitTest.java
@@ -25,4 +25,12 @@ public class AIMDLimitTest {
         limiter.onSample(0, 0, 0, true);
         Assert.assertEquals(27, limiter.getLimit());
     }
+
+    @Test
+    public void successOverflow() {
+        AIMDLimit limiter = AIMDLimit.newBuilder().initialLimit(21).maxLimit(21).minLimit(0).build();
+        limiter.onSample(0, TimeUnit.MILLISECONDS.toNanos(1), 10, false);
+        // after success limit should still be at the max.
+        Assert.assertEquals(21, limiter.getLimit());
+    }
 }


### PR DESCRIPTION
after talking with @jolynch this section doesn't make sense if the next line bounds the limit between the min/max. #155 

mentioned in #72
> With AIMD, this works moderately well - eventually the client goes above the rate limit and a request is dropped. The next window, the concurrency is dropped by half, which generally will correspondingly drop the concurrency too, and cause the rate limit to be missed.

tangentially related to issue #147.

