### PR TITLE
Migrate project to java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ subprojects {
     repositories {
         mavenCentral()
         maven { url 'https://jitpack.io' }
-        maven {
-            url = 'https://repo.spring.io/milestone'
-        }
     }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,24 +9,31 @@ buildscript {
     }
     dependencies {
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.2'
+        classpath "com.netflix.nebula:gradle-netflixoss-project-plugin:11.0.0"
     }
 }
 
 plugins {
-    id 'nebula.netflixoss' version '10.6.0'
+    id 'com.netflix.nebula.netflixoss' version '11.0.0'
 }
 
 // Establish version and status
 ext.githubProjectName = rootProject.name 
 
 subprojects {
-    apply plugin: 'nebula.netflixoss'
+    apply plugin: 'com.netflix.nebula.netflixoss'
     apply plugin: 'java-library'
-    group = "com.netflix.${githubProjectName}" 
+    group = "com.netflix.${githubProjectName}"
+
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     repositories {
         mavenCentral()
         maven { url 'https://jitpack.io' }
+        maven {
+            url = 'https://repo.spring.io/milestone'
+        }
     }
 
 
@@ -35,12 +42,18 @@ subprojects {
         jUnitVersion = "5.+"
         jUnitLegacyVersion = "4.+"
         mockitoVersion = "4.+"
-        slf4jVersion = "1.7.+"
+        slf4jVersion = "2.+"
         spectatorVersion = "1.+"
-        springVersion = "5.+"
+        springVersion = "6.+"
     }
 
     tasks.withType(Test) {
         useJUnitPlatform()
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }

--- a/concurrency-limits-core/build.gradle
+++ b/concurrency-limits-core/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
 
 dependencies {
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"

--- a/concurrency-limits-core/dependencies.lock
+++ b/concurrency-limits-core/dependencies.lock
@@ -1,12 +1,12 @@
 {
     "compileClasspath": {
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "runtimeClasspath": {
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "testCompileClasspath": {
@@ -14,10 +14,10 @@
             "locked": "4.13.2"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "testRuntimeClasspath": {
@@ -28,10 +28,10 @@
             "locked": "5.9.1"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     }
 }

--- a/concurrency-limits-core/dependencies.lock
+++ b/concurrency-limits-core/dependencies.lock
@@ -1,12 +1,12 @@
 {
     "compileClasspath": {
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "runtimeClasspath": {
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "testCompileClasspath": {
@@ -14,24 +14,24 @@
             "locked": "4.13.2"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "testRuntimeClasspath": {
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.junit.vintage:junit-vintage-engine": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     }
 }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/LifoBlockingLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/LifoBlockingLimiter.java
@@ -60,6 +60,7 @@ public final class LifoBlockingLimiter<ContextT> implements Limiter<ContextT> {
         /**
          * @deprecated Use {@link #backlogSize}
          */
+        @Deprecated
         public Builder<ContextT> maxBacklogSize(int size) {
             this.maxBacklogSize = size;
             return this;

--- a/concurrency-limits-grpc/build.gradle
+++ b/concurrency-limits-grpc/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
 
 dependencies {
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"

--- a/concurrency-limits-grpc/dependencies.lock
+++ b/concurrency-limits-grpc/dependencies.lock
@@ -32,7 +32,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-spectator"
             ],
-            "locked": "1.3.9"
+            "locked": "1.4.0"
         },
         "io.grpc:grpc-netty": {
             "locked": "1.9.0"
@@ -47,7 +47,7 @@
             "locked": "3.6.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.8.1"
+            "locked": "4.9.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.3"
@@ -70,7 +70,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-spectator"
             ],
-            "locked": "1.3.9"
+            "locked": "1.4.0"
         },
         "io.grpc:grpc-netty": {
             "locked": "1.9.0"
@@ -88,7 +88,7 @@
             "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.8.1"
+            "locked": "4.9.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/concurrency-limits-grpc/dependencies.lock
+++ b/concurrency-limits-grpc/dependencies.lock
@@ -7,7 +7,7 @@
             "locked": "1.9.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "runtimeClasspath": {
@@ -18,7 +18,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "testCompileClasspath": {
@@ -32,7 +32,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-spectator"
             ],
-            "locked": "1.4.0"
+            "locked": "1.4.1"
         },
         "io.grpc:grpc-netty": {
             "locked": "1.9.0"
@@ -50,10 +50,10 @@
             "locked": "4.9.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "testRuntimeClasspath": {
@@ -70,7 +70,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-spectator"
             ],
-            "locked": "1.4.0"
+            "locked": "1.4.1"
         },
         "io.grpc:grpc-netty": {
             "locked": "1.9.0"
@@ -95,10 +95,10 @@
                 "com.netflix.concurrency-limits:concurrency-limits-core",
                 "com.netflix.concurrency-limits:concurrency-limits-spectator"
             ],
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     }
 }

--- a/concurrency-limits-grpc/dependencies.lock
+++ b/concurrency-limits-grpc/dependencies.lock
@@ -7,7 +7,7 @@
             "locked": "1.9.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "runtimeClasspath": {
@@ -18,7 +18,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "testCompileClasspath": {
@@ -32,7 +32,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-spectator"
             ],
-            "locked": "1.3.6"
+            "locked": "1.3.9"
         },
         "io.grpc:grpc-netty": {
             "locked": "1.9.0"
@@ -47,13 +47,13 @@
             "locked": "3.6.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.7.0"
+            "locked": "4.8.1"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -70,7 +70,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-spectator"
             ],
-            "locked": "1.3.6"
+            "locked": "1.3.9"
         },
         "io.grpc:grpc-netty": {
             "locked": "1.9.0"
@@ -82,23 +82,23 @@
             "locked": "3.6.1"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.junit.vintage:junit-vintage-engine": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.7.0"
+            "locked": "4.8.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core",
                 "com.netflix.concurrency-limits:concurrency-limits-spectator"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     }
 }

--- a/concurrency-limits-servlet/build.gradle
+++ b/concurrency-limits-servlet/build.gradle
@@ -4,9 +4,14 @@ plugins {
 
 sourceCompatibility = JavaVersion.VERSION_17
 
+// give test dependencies access to compileOnly dependencies to emulate providedCompile
+configurations {
+    testImplementation.extendsFrom compileOnly
+}
+
 dependencies {
     api project(":concurrency-limits-core")
-    compileOnly "jakarta.servlet:jakarta.servlet-api:5.0.0"
+    compileOnly "jakarta.servlet:jakarta.servlet-api:6.0.0"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
 
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"

--- a/concurrency-limits-servlet/build.gradle
+++ b/concurrency-limits-servlet/build.gradle
@@ -2,18 +2,18 @@ plugins {
     id 'java'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
 
 dependencies {
     api project(":concurrency-limits-core")
-    compileOnly "javax.servlet:javax.servlet-api:3.1.0"
+    compileOnly "jakarta.servlet:jakarta.servlet-api:5.0.0"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
 
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testImplementation "org.slf4j:slf4j-log4j12:${slf4jVersion}"
-    testImplementation "org.eclipse.jetty:jetty-server:9.4.+"
-    testImplementation "org.eclipse.jetty:jetty-servlet:9.4.+"
+    testImplementation "org.eclipse.jetty:jetty-server:11.+"
+    testImplementation "org.eclipse.jetty:jetty-servlet:11.+"
     testCompileOnly "junit:junit:${jUnitLegacyVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${jUnitVersion}"
     testImplementation "org.springframework:spring-test:${springVersion}"

--- a/concurrency-limits-servlet/dependencies.lock
+++ b/concurrency-limits-servlet/dependencies.lock
@@ -4,7 +4,7 @@
             "project": true
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "5.0.0"
+            "locked": "6.0.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.3"
@@ -38,10 +38,10 @@
             "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.8.1"
+            "locked": "4.9.0"
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "4.8.1"
+            "locked": "4.9.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.3"
@@ -50,7 +50,7 @@
             "locked": "2.0.3"
         },
         "org.springframework:spring-test": {
-            "locked": "6.0.0-RC2"
+            "locked": "6.0.0"
         }
     },
     "testRuntimeClasspath": {
@@ -73,10 +73,10 @@
             "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.8.1"
+            "locked": "4.9.0"
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "4.8.1"
+            "locked": "4.9.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -88,7 +88,7 @@
             "locked": "2.0.3"
         },
         "org.springframework:spring-test": {
-            "locked": "6.0.0-RC2"
+            "locked": "6.0.0"
         }
     }
 }

--- a/concurrency-limits-servlet/dependencies.lock
+++ b/concurrency-limits-servlet/dependencies.lock
@@ -3,11 +3,11 @@
         "com.netflix.concurrency-limits:concurrency-limits-core": {
             "project": true
         },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "3.1.0"
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "5.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "runtimeClasspath": {
@@ -18,7 +18,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "testCompileClasspath": {
@@ -29,28 +29,28 @@
             "locked": "4.13.2"
         },
         "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.48.v20220622"
+            "locked": "11.0.12"
         },
         "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.48.v20220622"
+            "locked": "11.0.12"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.7.0"
+            "locked": "4.8.1"
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "4.7.0"
+            "locked": "4.8.1"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         },
         "org.springframework:spring-test": {
-            "locked": "5.3.22"
+            "locked": "6.0.0-RC2"
         }
     },
     "testRuntimeClasspath": {
@@ -58,37 +58,37 @@
             "project": true
         },
         "org.eclipse.jetty:jetty-server": {
-            "locked": "9.4.48.v20220622"
+            "locked": "11.0.12"
         },
         "org.eclipse.jetty:jetty-servlet": {
-            "locked": "9.4.48.v20220622"
+            "locked": "11.0.12"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.junit.vintage:junit-vintage-engine": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.7.0"
+            "locked": "4.8.1"
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "4.7.0"
+            "locked": "4.8.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         },
         "org.springframework:spring-test": {
-            "locked": "5.3.22"
+            "locked": "6.0.0-RC2"
         }
     }
 }

--- a/concurrency-limits-servlet/dependencies.lock
+++ b/concurrency-limits-servlet/dependencies.lock
@@ -7,7 +7,7 @@
             "locked": "6.0.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "runtimeClasspath": {
@@ -18,12 +18,15 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "testCompileClasspath": {
         "com.netflix.concurrency-limits:concurrency-limits-core": {
             "project": true
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
         },
         "junit:junit": {
             "locked": "4.13.2"
@@ -44,18 +47,21 @@
             "locked": "4.9.0"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         },
         "org.springframework:spring-test": {
-            "locked": "6.0.0"
+            "locked": "6.0.2"
         }
     },
     "testRuntimeClasspath": {
         "com.netflix.concurrency-limits:concurrency-limits-core": {
             "project": true
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
         },
         "org.eclipse.jetty:jetty-server": {
             "locked": "11.0.12"
@@ -82,13 +88,13 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         },
         "org.slf4j:slf4j-log4j12": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         },
         "org.springframework:spring-test": {
-            "locked": "6.0.0"
+            "locked": "6.0.2"
         }
     }
 }

--- a/concurrency-limits-servlet/src/main/java/com/netflix/concurrency/limits/servlet/ConcurrencyLimitServletFilter.java
+++ b/concurrency-limits-servlet/src/main/java/com/netflix/concurrency/limits/servlet/ConcurrencyLimitServletFilter.java
@@ -20,14 +20,14 @@ import com.netflix.concurrency.limits.Limiter;
 import java.io.IOException;
 import java.util.Optional;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Servlet {@link Filter} that enforces concurrency limits on all requests into the servlet.

--- a/concurrency-limits-servlet/src/main/java/com/netflix/concurrency/limits/servlet/ServletLimiterBuilder.java
+++ b/concurrency-limits-servlet/src/main/java/com/netflix/concurrency/limits/servlet/ServletLimiterBuilder.java
@@ -18,7 +18,7 @@ package com.netflix.concurrency.limits.servlet;
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limiter.AbstractPartitionedLimiter;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
 import java.util.function.Function;

--- a/concurrency-limits-servlet/src/test/java/com/netflix/concurrency/limits/ConcurrencyLimitServletFilterSimulationTest.java
+++ b/concurrency-limits-servlet/src/test/java/com/netflix/concurrency/limits/ConcurrencyLimitServletFilterSimulationTest.java
@@ -11,11 +11,11 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import javax.servlet.DispatcherType;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.EnumSet;

--- a/concurrency-limits-servlet/src/test/java/com/netflix/concurrency/limits/ConcurrencyLimitServletFilterSimulationTest.java
+++ b/concurrency-limits-servlet/src/test/java/com/netflix/concurrency/limits/ConcurrencyLimitServletFilterSimulationTest.java
@@ -12,7 +12,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import jakarta.servlet.DispatcherType;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -73,7 +72,7 @@ public class ConcurrencyLimitServletFilterSimulationTest {
         private static final long serialVersionUID = 1L;
 
         @Override
-        protected void doGet( HttpServletRequest request, HttpServletResponse response ) throws ServletException, IOException {
+        protected void doGet( HttpServletRequest request, HttpServletResponse response ) throws IOException {
             try {
                 TimeUnit.MILLISECONDS.sleep(100);
             } catch (InterruptedException e) {

--- a/concurrency-limits-servlet/src/test/java/com/netflix/concurrency/limits/ConcurrencyLimitServletFilterTest.java
+++ b/concurrency-limits-servlet/src/test/java/com/netflix/concurrency/limits/ConcurrencyLimitServletFilterTest.java
@@ -5,15 +5,13 @@ import com.netflix.concurrency.limits.servlet.ConcurrencyLimitServletFilter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Optional;
 

--- a/concurrency-limits-servlet/src/test/java/com/netflix/concurrency/limits/GroupServletLimiterTest.java
+++ b/concurrency-limits-servlet/src/test/java/com/netflix/concurrency/limits/GroupServletLimiterTest.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/concurrency-limits-spectator/build.gradle
+++ b/concurrency-limits-spectator/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
 
 dependencies {
     implementation project(":concurrency-limits-core")

--- a/concurrency-limits-spectator/dependencies.lock
+++ b/concurrency-limits-spectator/dependencies.lock
@@ -4,7 +4,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.4.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.3"
@@ -15,7 +15,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.4.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -29,7 +29,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.4.0"
         },
         "junit:junit": {
             "locked": "4.13.2"
@@ -43,7 +43,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.4.0"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.9.1"

--- a/concurrency-limits-spectator/dependencies.lock
+++ b/concurrency-limits-spectator/dependencies.lock
@@ -4,10 +4,10 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.4.0"
+            "locked": "1.4.1"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "runtimeClasspath": {
@@ -15,13 +15,13 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.4.0"
+            "locked": "1.4.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "testCompileClasspath": {
@@ -29,13 +29,13 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.4.0"
+            "locked": "1.4.1"
         },
         "junit:junit": {
             "locked": "4.13.2"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     },
     "testRuntimeClasspath": {
@@ -43,7 +43,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.4.0"
+            "locked": "1.4.1"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.9.1"
@@ -55,7 +55,7 @@
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "2.0.3"
+            "locked": "2.0.4"
         }
     }
 }

--- a/concurrency-limits-spectator/dependencies.lock
+++ b/concurrency-limits-spectator/dependencies.lock
@@ -4,10 +4,10 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.6"
+            "locked": "1.3.9"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "runtimeClasspath": {
@@ -15,13 +15,13 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.6"
+            "locked": "1.3.9"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "testCompileClasspath": {
@@ -29,13 +29,13 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.6"
+            "locked": "1.3.9"
         },
         "junit:junit": {
             "locked": "4.13.2"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -43,19 +43,19 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.6"
+            "locked": "1.3.9"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.junit.vintage:junit-vintage-engine": {
-            "locked": "5.9.0"
+            "locked": "5.9.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.concurrency-limits:concurrency-limits-core"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.3"
         }
     }
 }


### PR DESCRIPTION
I'm preparing the migration of one of my projects to [Spring Boot 3](https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0) and [Spring 6](https://spring.io/blog/2022/11/16/spring-framework-6-0-goes-ga). These versions come with a Java 17+ baseline and a move to Jakarta EE 9+ (in the jakarta namespace), with a focus on the recently released Jakarta EE 10 APIs such as Servlet 6.0. 
The (surprisingly) only issue I'm facing it the `concurrency-limits-servlet` dependency since it still depends on Servlet 3.1. 

I took the liberty to migrate the `concurrency-limits` project to Java 17, Spring 6 and Servlet 6.0. I understand this is quit a breaking change but I took this naive approach to start a discussion on the upgrade path for the project. 