### PR TITLE
Ensure the inflight metrics are properly updated when rejecting

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/SimpleLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/SimpleLimiter.java
@@ -49,12 +49,16 @@ public class SimpleLimiter<ContextT> extends AbstractLimiter<ContextT> {
 
     @Override
     public Optional<Limiter.Listener> acquire(ContextT context) {
+        Optional<Limiter.Listener> listener;
         if (!semaphore.tryAcquire()) {
-            return createRejectedListener();
+            listener = createRejectedListener();
         }
-        Listener listener = new Listener(createListener());
+        else {
+            listener = Optional.of(new Listener(createListener()));
+        }
+
         inflightDistribution.addSample(getInflight());
-        return Optional.of(listener);
+        return listener;
     }
 
     @Override


### PR DESCRIPTION
Currently, the inflight metrics only update when a successful listener is acquired. However, in cases where all inflight requests are tied up and everything is being rejected, the inflight counter never updates. This causes the metric to eventually fall off and "appear" as 0 inflight. This change always publishes the inflight distribution to ensure it is always published with its current value.