### PR TITLE
Restore bytecode compatibility for limiter builders

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractLimiter.java
@@ -31,34 +31,6 @@ public abstract class AbstractLimiter<ContextT> implements Limiter<ContextT> {
     public static final String ID_TAG = "id";
     public static final String STATUS_TAG = "status";
 
-    /**
-     * Constructs a new builder with a list of bypass resolvers.
-     * If the predicate condition in any of the resolver is satisfied,
-     * the call is bypassed without increasing the limiter inflight count
-     * and affecting the algorithm.
-     */
-    public abstract static class BypassLimiterBuilder<BuilderT extends BypassLimiterBuilder<BuilderT, ContextT>, ContextT> extends Builder<BuilderT> {
-
-        private final Predicate<ContextT> ALWAYS_FALSE = (context) -> false;
-        private Predicate<ContextT> bypassResolver = ALWAYS_FALSE;
-
-        /**
-         * Add a chainable bypass resolver predicate from context. Multiple resolvers may be added and if any of the
-         * predicate condition returns true the call is bypassed without increasing the limiter inflight count and
-         * affecting the algorithm. Will not bypass any calls by default if no resolvers are added.
-         * @param shouldBypass Predicate condition to bypass limit
-         * @return Chainable builder
-         */
-        public BuilderT bypassLimitResolver(Predicate<ContextT> shouldBypass) {
-            if (this.bypassResolver == ALWAYS_FALSE) {
-                this.bypassResolver = shouldBypass;
-            } else {
-                this.bypassResolver = bypassResolver.or(shouldBypass);
-            }
-            return self();
-        }
-    }
-
     public abstract static class Builder<BuilderT extends Builder<BuilderT>> {
         private static final AtomicInteger idCounter = new AtomicInteger();
 
@@ -67,6 +39,9 @@ public abstract class AbstractLimiter<ContextT> implements Limiter<ContextT> {
 
         protected String name = "unnamed-" + idCounter.incrementAndGet();
         protected MetricRegistry registry = EmptyMetricRegistry.INSTANCE;
+
+        private final Predicate<Object> ALWAYS_FALSE = (context) -> false;
+        private Predicate<Object> bypassResolver = ALWAYS_FALSE;
 
         public BuilderT named(String name) {
             this.name = name;
@@ -89,6 +64,26 @@ public abstract class AbstractLimiter<ContextT> implements Limiter<ContextT> {
         }
 
         protected abstract BuilderT self();
+
+        /**
+         * Add a chainable bypass resolver predicate from context. Multiple resolvers may be added and if any of the
+         * predicate condition returns true the call is bypassed without increasing the limiter inflight count and
+         * affecting the algorithm. Will not bypass any calls by default if no resolvers are added.
+         *
+         * Due to the builders not having access to the ContextT, it is the duty of subclasses to ensure that
+         * implementations are type safe.
+         *
+         * @param shouldBypass Predicate condition to bypass limit
+         * @return Chainable builder
+         */
+        protected BuilderT bypassLimitResolverInternal(Predicate<?> shouldBypass) {
+            if (this.bypassResolver == ALWAYS_FALSE) {
+                this.bypassResolver = (Predicate<Object>) shouldBypass;
+            } else {
+                this.bypassResolver = bypassResolver.or((Predicate<Object>) shouldBypass);
+            }
+            return self();
+        }
     }
 
     private final AtomicInteger inFlight = new AtomicInteger();
@@ -108,9 +103,8 @@ public abstract class AbstractLimiter<ContextT> implements Limiter<ContextT> {
         this.limitAlgorithm = builder.limit;
         this.limit = limitAlgorithm.getLimit();
         this.limitAlgorithm.notifyOnChange(this::onNewLimit);
-        if (builder instanceof BypassLimiterBuilder) {
-            this.bypassResolver = ((BypassLimiterBuilder) builder).bypassResolver;
-        }
+        this.bypassResolver = (Predicate<ContextT>) builder.bypassResolver;
+
         builder.registry.gauge(MetricIds.LIMIT_NAME, this::getLimit);
         this.successCounter = builder.registry.counter(MetricIds.CALL_NAME, ID_TAG, builder.name, STATUS_TAG, "success");
         this.droppedCounter = builder.registry.counter(MetricIds.CALL_NAME, ID_TAG, builder.name, STATUS_TAG, "dropped");

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -37,7 +37,7 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
     private static final Logger LOG = LoggerFactory.getLogger(AbstractPartitionedLimiter.class);
     private static final String PARTITION_TAG_NAME = "partition";
 
-    public abstract static class Builder<BuilderT extends AbstractLimiter.BypassLimiterBuilder<BuilderT, ContextT>, ContextT> extends AbstractLimiter.BypassLimiterBuilder<BuilderT, ContextT> {
+    public abstract static class Builder<BuilderT extends AbstractLimiter.Builder<BuilderT>, ContextT> extends AbstractLimiter.Builder<BuilderT> {
         private List<Function<ContextT, String>> partitionResolvers = new ArrayList<>();
         private final Map<String, Partition> partitions = new LinkedHashMap<>();
         private int maxDelayedThreads = 100;

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/SimpleLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/SimpleLimiter.java
@@ -23,18 +23,6 @@ import java.util.Optional;
 import java.util.concurrent.Semaphore;
 
 public class SimpleLimiter<ContextT> extends AbstractLimiter<ContextT> {
-
-    public static class BypassLimiterBuilder<ContextT> extends AbstractLimiter.BypassLimiterBuilder<BypassLimiterBuilder<ContextT>, ContextT> {
-        public SimpleLimiter<ContextT> build() {
-            return new SimpleLimiter<>(this);
-        }
-
-        @Override
-        protected BypassLimiterBuilder<ContextT> self() {
-            return this;
-        }
-    }
-
     public static class Builder extends AbstractLimiter.Builder<Builder> {
         public <ContextT> SimpleLimiter<ContextT> build() {
             return new SimpleLimiter<>(this);
@@ -46,10 +34,6 @@ public class SimpleLimiter<ContextT> extends AbstractLimiter<ContextT> {
         }
     }
 
-    public static <ContextT> BypassLimiterBuilder<ContextT> newBypassLimiterBuilder() {
-        return new BypassLimiterBuilder<>();
-    }
-
     public static Builder newBuilder() {
         return new Builder();
     }
@@ -58,6 +42,7 @@ public class SimpleLimiter<ContextT> extends AbstractLimiter<ContextT> {
 
     public SimpleLimiter(AbstractLimiter.Builder<?> builder) {
         super(builder);
+
         this.inflightDistribution = builder.registry.distribution(MetricIds.INFLIGHT_NAME);
         this.semaphore = new AdjustableSemaphore(getLimit());
     }

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiterTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiterTest.java
@@ -173,7 +173,7 @@ public class AbstractPartitionedLimiterTest {
                 .partition("batch", 0.1)
                 .partition("live", 0.9)
                 .limit(FixedLimit.of(10))
-                .bypassLimitResolver(new ShouldBypassPredicate())
+                .bypassLimitResolverInternal(new ShouldBypassPredicate())
                 .build();
 
         Assert.assertTrue(limiter.acquire("batch").isPresent());
@@ -200,7 +200,7 @@ public class AbstractPartitionedLimiterTest {
 
         SimpleLimiter<String> limiter = (SimpleLimiter<String>) TestPartitionedLimiter.newBuilder()
                 .limit(FixedLimit.of(10))
-                .bypassLimitResolver(new ShouldBypassPredicate())
+                .bypassLimitResolverInternal(new ShouldBypassPredicate())
                 .build();
 
         int inflightCount = 0;

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/SimpleLimiterTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/SimpleLimiterTest.java
@@ -48,9 +48,9 @@ public class SimpleLimiterTest {
 
     @Test
     public void testSimpleBypassLimiter() {
-        SimpleLimiter<String> limiter = SimpleLimiter.<String>newBypassLimiterBuilder()
+        SimpleLimiter<String> limiter = SimpleLimiter.<String>newBuilder()
                 .limit(FixedLimit.of(10))
-                .bypassLimitResolver((context) -> context.equals("admin"))
+                .bypassLimitResolverInternal((context) -> context.equals("admin"))
                 .build();
 
         for (int i = 0; i < 10; i++) {
@@ -68,7 +68,7 @@ public class SimpleLimiterTest {
 
     @Test
     public void testSimpleBypassLimiterDefault() {
-        SimpleLimiter<String> limiter = SimpleLimiter.<String>newBypassLimiterBuilder()
+        SimpleLimiter<String> limiter = SimpleLimiter.<String>newBuilder()
                 .limit(FixedLimit.of(10))
                 .build();
 

--- a/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/client/GrpcClientLimiterBuilder.java
+++ b/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/client/GrpcClientLimiterBuilder.java
@@ -19,6 +19,7 @@ import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limiter.AbstractPartitionedLimiter;
 import com.netflix.concurrency.limits.limiter.BlockingLimiter;
 import io.grpc.CallOptions;
+import java.util.function.Predicate;
 
 /**
  * Builder to simplify creating a {@link Limiter} specific to GRPC clients. 
@@ -32,6 +33,18 @@ public final class GrpcClientLimiterBuilder extends AbstractPartitionedLimiter.B
     
     public GrpcClientLimiterBuilder partitionByCallOption(CallOptions.Key<String> option) {
         return partitionResolver(context -> context.getCallOptions().getOption(option));
+    }
+
+    /**
+     * Add a chainable bypass resolver predicate from context. Multiple resolvers may be added and if any of the
+     * predicate condition returns true the call is bypassed without increasing the limiter inflight count and
+     * affecting the algorithm. Will not bypass any calls by default if no resolvers are added.
+     *
+     * @param shouldBypass Predicate condition to bypass limit
+     * @return Chainable builder
+     */
+    public GrpcClientLimiterBuilder bypassLimitResolver(Predicate<GrpcClientRequestContext> shouldBypass) {
+        return bypassLimitResolverInternal(shouldBypass);
     }
 
     /**

--- a/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/server/GrpcServerLimiterBuilder.java
+++ b/concurrency-limits-grpc/src/main/java/com/netflix/concurrency/limits/grpc/server/GrpcServerLimiterBuilder.java
@@ -18,6 +18,7 @@ package com.netflix.concurrency.limits.grpc.server;
 import com.netflix.concurrency.limits.limiter.AbstractPartitionedLimiter;
 import io.grpc.Attributes;
 import io.grpc.Metadata;
+import java.util.function.Predicate;
 
 public class GrpcServerLimiterBuilder extends AbstractPartitionedLimiter.Builder<GrpcServerLimiterBuilder, GrpcServerRequestContext> {
     /**
@@ -42,6 +43,19 @@ public class GrpcServerLimiterBuilder extends AbstractPartitionedLimiter.Builder
      */
     public GrpcServerLimiterBuilder partitionByAttribute(Attributes.Key<String> attribute) {
         return partitionResolver(context -> context.getCall().getAttributes().get(attribute));
+    }
+
+
+    /**
+     * Add a chainable bypass resolver predicate from context. Multiple resolvers may be added and if any of the
+     * predicate condition returns true the call is bypassed without increasing the limiter inflight count and
+     * affecting the algorithm. Will not bypass any calls by default if no resolvers are added.
+     *
+     * @param shouldBypass Predicate condition to bypass limit
+     * @return Chainable builder
+     */
+    public GrpcServerLimiterBuilder bypassLimitResolver(Predicate<GrpcServerRequestContext> shouldBypass) {
+        return bypassLimitResolverInternal(shouldBypass);
     }
 
     /**

--- a/concurrency-limits-servlet-jakarta/src/main/java/com/netflix/concurrency/limits/servlet/jakarta/ServletLimiterBuilder.java
+++ b/concurrency-limits-servlet-jakarta/src/main/java/com/netflix/concurrency/limits/servlet/jakarta/ServletLimiterBuilder.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Builder to simplify creating a {@link Limiter} specific to a Servlet filter. By default,
@@ -71,6 +72,18 @@ public final class ServletLimiterBuilder extends AbstractPartitionedLimiter.Buil
      */
     public ServletLimiterBuilder partitionByPathInfo(Function<String, String> pathToGroup) {
         return partitionResolver(request -> Optional.ofNullable(request.getPathInfo()).map(pathToGroup).orElse(null));
+    }
+
+    /**
+     * Add a chainable bypass resolver predicate from context. Multiple resolvers may be added and if any of the
+     * predicate condition returns true the call is bypassed without increasing the limiter inflight count and
+     * affecting the algorithm. Will not bypass any calls by default if no resolvers are added.
+     *
+     * @param shouldBypass Predicate condition to bypass limit
+     * @return Chainable builder
+     */
+    public ServletLimiterBuilder bypassLimitResolver(Predicate<HttpServletRequest> shouldBypass) {
+        return bypassLimitResolverInternal(shouldBypass);
     }
 
     /**

--- a/concurrency-limits-servlet/src/main/java/com/netflix/concurrency/limits/servlet/ServletLimiterBuilder.java
+++ b/concurrency-limits-servlet/src/main/java/com/netflix/concurrency/limits/servlet/ServletLimiterBuilder.java
@@ -18,6 +18,7 @@ package com.netflix.concurrency.limits.servlet;
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limiter.AbstractPartitionedLimiter;
 
+import java.util.function.Predicate;
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.Optional;
@@ -71,6 +72,18 @@ public final class ServletLimiterBuilder extends AbstractPartitionedLimiter.Buil
      */
     public ServletLimiterBuilder partitionByPathInfo(Function<String, String> pathToGroup) {
         return partitionResolver(request -> Optional.ofNullable(request.getPathInfo()).map(pathToGroup).orElse(null));
+    }
+
+    /**
+     * Add a chainable bypass resolver predicate from context. Multiple resolvers may be added and if any of the
+     * predicate condition returns true the call is bypassed without increasing the limiter inflight count and
+     * affecting the algorithm. Will not bypass any calls by default if no resolvers are added.
+     *
+     * @param shouldBypass Predicate condition to bypass limit
+     * @return Chainable builder
+     */
+    public ServletLimiterBuilder bypassLimitResolver(Predicate<HttpServletRequest> shouldBypass) {
+        return bypassLimitResolverInternal(shouldBypass);
     }
 
     /**


### PR DESCRIPTION
#194 accidentally broke binary compatibility for the limiter builders. This PR restores compatibility by explicitly deferring type-safety responsibility for bypass resolvers to the implementing subclasses.