### PR TITLE
Use getServletPath instead of getPathInfo for jakarta servlets

### DIFF
--- a/concurrency-limits-servlet-jakarta/src/main/java/com/netflix/concurrency/limits/servlet/jakarta/ServletLimiterBuilder.java
+++ b/concurrency-limits-servlet-jakarta/src/main/java/com/netflix/concurrency/limits/servlet/jakarta/ServletLimiterBuilder.java
@@ -71,7 +71,7 @@ public final class ServletLimiterBuilder extends AbstractPartitionedLimiter.Buil
      * @return Chainable builder
      */
     public ServletLimiterBuilder partitionByPathInfo(Function<String, String> pathToGroup) {
-        return partitionResolver(request -> Optional.ofNullable(request.getPathInfo()).map(pathToGroup).orElse(null));
+        return partitionResolver(request -> Optional.ofNullable(request.getServletPath()).map(pathToGroup).orElse(null));
     }
 
     /**
@@ -129,7 +129,7 @@ public final class ServletLimiterBuilder extends AbstractPartitionedLimiter.Buil
      * @return Chainable builder
      */
     public ServletLimiterBuilder bypassLimitByPathInfo(String pathInfo) {
-        return bypassLimitResolver((context) -> pathInfo.equals(context.getPathInfo()));
+        return bypassLimitResolver((context) -> pathInfo.equals(context.getServletPath()));
     }
 
     /**

--- a/concurrency-limits-servlet-jakarta/src/test/java/com/netflix/concurrency/limits/ConcurrencyLimitServletFilterTest.java
+++ b/concurrency-limits-servlet-jakarta/src/test/java/com/netflix/concurrency/limits/ConcurrencyLimitServletFilterTest.java
@@ -119,7 +119,7 @@ public class ConcurrencyLimitServletFilterTest {
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setMethod("POST");
-        request.setPathInfo("/admin/health");
+        request.setServletPath("/admin/health");
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain filterChain = new MockFilterChain();
 

--- a/concurrency-limits-servlet-jakarta/src/test/java/com/netflix/concurrency/limits/GroupServletLimiterTest.java
+++ b/concurrency-limits-servlet-jakarta/src/test/java/com/netflix/concurrency/limits/GroupServletLimiterTest.java
@@ -166,7 +166,7 @@ public class GroupServletLimiterTest {
     private HttpServletRequest createMockRequestWithPathInfo(String name) {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 
-        Mockito.when(request.getPathInfo()).thenReturn(name);
+        Mockito.when(request.getServletPath()).thenReturn(name);
         return request;
     }
 }


### PR DESCRIPTION
With jakarta servlet APIs getPathInfo returns null. getServletPath can be used as an alternative here.

https://stackoverflow.com/a/3745971/552525