### PR TITLE
Prevent duplicate publishing on release

### DIFF
--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -4,9 +4,6 @@ on:
     tags:
       - v*.*.*
       - v*.*.*-rc.*
-  release:
-    types:
-      - published
 
 jobs:
   build:


### PR DESCRIPTION
Current config triggers the publish github action job twice resulting in one of the builds to fail.

Updated the config to only run the action once on a new tag push.