### PR TITLE
Reduce contention a little in AbstractPartitionedLimiter

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractLimiter.java
@@ -73,6 +73,10 @@ public abstract class AbstractLimiter<ContextT> implements Limiter<ContextT> {
          * Due to the builders not having access to the ContextT, it is the duty of subclasses to ensure that
          * implementations are type safe.
          *
+         * Predicates should not rely strictly on state of the Limiter (such as inflight count) when evaluating
+         * whether to bypass. There is no guarantee that the state will be synchronized or consistent with respect to
+         * the bypass predicate, and the bypass predicate may be called by multiple threads concurrently.
+         *
          * @param shouldBypass Predicate condition to bypass limit
          * @return Chainable builder
          */

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -261,12 +261,15 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
     }
 
     private void releasePartition(Partition partition) {
-        try {
-            lock.lock();
-            partition.release();
-        } finally {
-            lock.unlock();
-        }
+        // safety note:
+        // above, we enforce that only one thread can acquire at a time,
+        // and that code checks if the limit is exceeded before acquire
+        //
+        // possible that thread A checks and finds limit is exceeded and
+        // will go into backoff, while we do a concurrent release --
+        // but that is the same outcome (backoff) as if we had fully
+        // locked here and stalled before doing a release
+        partition.release();
     }
 
     @Override

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -239,12 +239,12 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
     public Optional<Listener> acquire(ContextT context) {
         final Partition partition = resolvePartition(context);
 
+        if (shouldBypass(context)){
+            return createBypassListener();
+        }
+
         try {
             lock.lock();
-            if (shouldBypass(context)){
-                lock.unlock();
-                return createBypassListener();
-            }
             if (getInflight() >= getLimit() && partition.isLimitExceeded()) {
                 lock.unlock();
                 if (partition.backoffMillis > 0 && delayedThreads.get() < maxDelayedThreads) {

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -108,7 +108,7 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
         private final AtomicInteger busy = new AtomicInteger(0);
 
         private double percent = 0.0;
-        private int limit = 0;
+        private volatile int limit = 0;
         private long backoffMillis = 0;
         private MetricRegistry.SampleListener inflightDistribution;
 

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -215,6 +215,7 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
         try {
             lock.lock();
             if (shouldBypass(context)){
+                lock.unlock();
                 return createBypassListener();
             }
             if (getInflight() >= getLimit() && partition.isLimitExceeded()) {
@@ -234,6 +235,8 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
             }
 
             partition.acquire();
+            lock.unlock();
+
             final Listener listener = createListener();
             return Optional.of(new Listener() {
                 @Override
@@ -255,6 +258,7 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
                 }
             });
         } finally {
+            // in theory a subclass could throw
             if (lock.isHeldByCurrentThread())
                 lock.unlock();
         }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -225,11 +225,11 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
 
     @Override
     public Optional<Listener> acquire(ContextT context) {
-        final Partition partition = resolvePartition(context);
-
         if (shouldBypass(context)){
             return createBypassListener();
         }
+
+        final Partition partition = resolvePartition(context);
 
         // This is a little unusual in that the partition is not a hard limit. It is
         // only a limit that it is applied if the global limit is exceeded. This allows

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -146,16 +146,16 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
          * @return
          */
         boolean tryAcquire() {
-            while (true) {
-                int current = busy.get();
-                if (current >= limit) {
-                    return false;
-                }
+            int current = busy.get();
+            while (current < limit) {
                 if (busy.compareAndSet(current, current + 1)) {
                     inflightDistribution.addSample(current + 1);
                     return true;
                 }
+                current = busy.get();
             }
+
+            return false;
         }
 
         void release() {

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -137,31 +137,30 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
             return busy.get() >= limit;
         }
 
-	/**
-         * @deprecated
-         * Prefer acquireAndGet() and acquirePostSample() instead.
+        /**
+         * @deprecated Prefer acquireAndGet() and acquirePostSample() instead.
          */
         @Deprecated
         void acquire() {
             busy.incrementAndGet();
         }
 
-	/**
-	 * Increment the busy count and return the new value.
-	 *
-	 * This method is intended to be used in conjunction with acquirePostSample().
-	 *
-	 * @return the new value of busy after incrementing
-	 */
+        /**
+         * Increment the busy count and return the new value.
+         *
+         * This method is intended to be used in conjunction with acquirePostSample().
+         *
+         * @return the new value of busy after incrementing
+         */
         private int acquireAndGet() {
             return busy.incrementAndGet();
         }
 
-	/**
-	 * Record the current busy count metric.
-	 *
-	 * This method is intended to be used in conjunction with acquireAndGet().
-	 */
+        /**
+         * Record the current busy count metric.
+         *
+         * This method is intended to be used in conjunction with acquireAndGet().
+         */
         private void acquirePostSample(int nowBusy) {
             // explicitly split this out because the metric might be expensive,
             // and we want to allow the lock to release as early as possible

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiterTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiterTest.java
@@ -298,23 +298,23 @@ public class AbstractPartitionedLimiterTest {
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
 
+        StringBuilder resultSummary = new StringBuilder();
         for (String partition : Arrays.asList("A", "B", "C")) {
-            System.out.println(partition + " success count: " + successCounts.get(partition).get());
-            System.out.println(partition + " rejection count: " + rejectionCounts.get(partition).get());
-            System.out.println(partition + " max concurrent: " + maxConcurrents.get(partition).get());
+            int successCount = successCounts.get(partition).get();
+            int rejectionCount = rejectionCounts.get(partition).get();
+            int maxConcurrent = maxConcurrents.get(partition).get();
 
-            // remember that we borrow unused capacity, so have to ignore local limit!
-            Assert.assertTrue("Max concurrent for " + partition + " should not exceed global limit, was: "
-                    + maxConcurrents.get(partition).get(),
-                    maxConcurrents.get(partition).get() <= LIMIT);
-            Assert.assertEquals("Total attempts for " + partition + " should equal success + rejections",
+            resultSummary.append(String.format("%s(success=%d,reject=%d,maxConcurrent=%d) ",
+                                 partition, successCount, rejectionCount, maxConcurrent));
+
+            Assert.assertTrue("Max concurrent for " + partition + " should not exceed global limit. " + resultSummary,
+                    maxConcurrent <= LIMIT);
+            Assert.assertEquals("Total attempts for " + partition + " should equal success + rejections. " + resultSummary,
                                 THREAD_COUNT * ITERATIONS,
-                                successCounts.get(partition).get() + rejectionCounts.get(partition).get());
+                                successCount + rejectionCount);
         }
 
-        // to test a global limit, we need to ensure that max inflight globally
-        // does not exceed the total limit, we allow some wiggle room for each thread to burst 1 over
-        Assert.assertTrue("Global max inflight should not exceed total limit, was: " + globalMaxInflight.get(),
+        Assert.assertTrue("Global max inflight should not exceed total limit. " + resultSummary,
                           globalMaxInflight.get() <= LIMIT + THREAD_COUNT);
     }
 

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/SimpleLimiterTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limiter/SimpleLimiterTest.java
@@ -140,12 +140,15 @@ public class SimpleLimiterTest {
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
 
-        System.out.println("Success count: " + successCount.get());
-        System.out.println("Rejection count: " + rejectionCount.get());
-        System.out.println("Max concurrent: " + maxConcurrent.get());
+        StringBuilder resultBuilder = new StringBuilder();
+        resultBuilder.append("Success count: ").append(successCount.get())
+                     .append(" | Rejection count: ").append(rejectionCount.get())
+                     .append(" | Max concurrent: ").append(maxConcurrent.get());
+        String results = resultBuilder.toString();
 
-        Assert.assertTrue("Max concurrent should not exceed limit", maxConcurrent.get() <= LIMIT);
-        Assert.assertEquals("Total attempts should equal success + rejections", 
+        Assert.assertTrue("Max concurrent should not exceed limit. " + results,
+                          maxConcurrent.get() <= LIMIT);
+        Assert.assertEquals("Total attempts should equal success + rejections. " + results,
                             THREAD_COUNT * ITERATIONS, successCount.get() + rejectionCount.get());
     }
 


### PR DESCRIPTION
Swap `busy` from an `int` to `AtomicInteger`, which eliminates need for a `release` to take the lock.

And while we are here, slim down the work done while holding the lock.