### PR TITLE
Add methods to SampleListener to handle primitives

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/MetricRegistry.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/MetricRegistry.java
@@ -27,6 +27,14 @@ public interface MetricRegistry {
      */
     interface SampleListener {
         void addSample(Number value);
+
+        default void addLongSample(long value) {
+            addSample(value);
+        }
+
+        default void addDoubleSample(double value) {
+            addSample(value);
+        }
     }
 
     interface Counter {

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/Gradient2Limit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/Gradient2Limit.java
@@ -268,9 +268,9 @@ public final class Gradient2Limit extends AbstractLimit {
         final double shortRtt = (double)rtt;
         final double longRtt = this.longRtt.add(rtt).doubleValue();
 
-        shortRttSampleListener.addSample(shortRtt);
-        longRttSampleListener.addSample(longRtt);
-        queueSizeSampleListener.addSample(queueSize);
+        shortRttSampleListener.addDoubleSample(shortRtt);
+        longRttSampleListener.addDoubleSample(longRtt);
+        queueSizeSampleListener.addDoubleSample(queueSize);
 
         // If the long RTT is substantially larger than the short RTT then reduce the long RTT measurement.
         // This can happen when latency returns to normal after a prolonged prior of excessive load.  Reducing the

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/GradientLimit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/GradientLimit.java
@@ -264,10 +264,10 @@ public final class GradientLimit extends AbstractLimit {
     @Override
     public int _update(final long startTime, final long rtt, final int inflight, final boolean didDrop) {
         lastRtt = rtt;
-        minWindowRttSampleListener.addSample(rtt);
+        minWindowRttSampleListener.addLongSample(rtt);
 
         final double queueSize = this.queueSize.apply((int)this.estimatedLimit);
-        queueSizeSampleListener.addSample(queueSize);
+        queueSizeSampleListener.addDoubleSample(queueSize);
 
         // Reset or probe for a new noload RTT and a new estimatedLimit.  It's necessary to cut the limit
         // in half to avoid having the limit drift upwards when the RTT is probed during heavy load.
@@ -283,7 +283,7 @@ public final class GradientLimit extends AbstractLimit {
         }
         
         final long rttNoLoad = rttNoLoadMeasurement.add(rtt).longValue();
-        minRttSampleListener.addSample(rttNoLoad);
+        minRttSampleListener.addLongSample(rttNoLoad);
         
         // Rtt could be higher than rtt_noload because of smoothing rtt noload updates
         // so set to 1.0 to indicate no queuing.  Otherwise calculate the slope and don't

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/VegasLimit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/VegasLimit.java
@@ -218,7 +218,7 @@ public class VegasLimit extends AbstractLimit {
             return (int)estimatedLimit;
         }
         
-        rttSampleListener.addSample(rtt_noload);
+        rttSampleListener.addLongSample(rtt_noload);
 
         return updateEstimatedLimit(rtt, inflight, didDrop);
     }

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/AbstractPartitionedLimiter.java
@@ -138,7 +138,7 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
 
         void acquire() {
             int nowBusy = busy.incrementAndGet();
-            inflightDistribution.addSample(nowBusy);
+            inflightDistribution.addLongSample(nowBusy);
         }
 
         /**
@@ -149,7 +149,7 @@ public abstract class AbstractPartitionedLimiter<ContextT> extends AbstractLimit
             int current = busy.get();
             while (current < limit) {
                 if (busy.compareAndSet(current, current + 1)) {
-                    inflightDistribution.addSample(current + 1);
+                    inflightDistribution.addLongSample(current + 1);
                     return true;
                 }
                 current = busy.get();

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/SimpleLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/SimpleLimiter.java
@@ -59,7 +59,7 @@ public class SimpleLimiter<ContextT> extends AbstractLimiter<ContextT> {
         else {
             listener = Optional.of(new Listener(createListener()));
         }
-        inflightDistribution.addSample(getInflight());
+        inflightDistribution.addLongSample(getInflight());
         return listener;
     }
 


### PR DESCRIPTION
Add two methods to SampleListener, addLongSample and addDoubleSample, which accept primitives and avoid boxing; default implementations are provided for backwards compatibility.