### PR TITLE
Use IntUnaryOperator / DoubleUnaryOperator in VegasLimit

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/functions/Log10RootFunction.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/functions/Log10RootFunction.java
@@ -19,28 +19,31 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 /**
- * Function used by limiters to calculate thredsholds using log10 of the current limit.  
+ * Function used by limiters to calculate thresholds using log10 of the current limit.
  * Here we pre-compute the log10 of numbers up to 1000 as an optimization.
+ *
+ * @deprecated use {@link Log10RootIntFunction}
  */
+@Deprecated
 public final class Log10RootFunction implements Function<Integer, Integer> {
     static final int[] lookup = new int[1000];
-    
+
     static {
         IntStream.range(0, 1000).forEach(i -> lookup[i] = Math.max(1, (int)Math.log10(i)));
     }
-    
+
     private static final Log10RootFunction INSTANCE = new Log10RootFunction();
-    
+
     /**
      * Create an instance of a function that returns : baseline + sqrt(limit)
-     * 
+     *
      * @param baseline
      * @return
      */
     public static Function<Integer, Integer> create(int baseline) {
         return INSTANCE.andThen(t -> t + baseline);
     }
-    
+
     @Override
     public Integer apply(Integer t) {
         return t < 1000 ? lookup[t] : (int)Math.log10(t);

--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/functions/Log10RootIntFunction.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/functions/Log10RootIntFunction.java
@@ -1,0 +1,37 @@
+package com.netflix.concurrency.limits.limit.functions;
+
+import java.util.function.IntUnaryOperator;
+
+/**
+ * Function used by limiters to calculate thresholds using log10 of the current limit.
+ * Here we pre-compute the log10 of numbers up to 1000 as an optimization.
+ */
+public final class Log10RootIntFunction implements IntUnaryOperator {
+
+    private Log10RootIntFunction() {}
+
+    private static final int[] lookup = new int[1000];
+
+    static {
+        for (int i = 0; i < lookup.length; i++) {
+            lookup[i] = Math.max(1, (int) Math.log10(i));
+        }
+    }
+
+    private static final Log10RootIntFunction INSTANCE = new Log10RootIntFunction();
+
+    /**
+     * Create an instance of a function that returns : baseline + sqrt(limit)
+     *
+     * @param baseline
+     * @return
+     */
+    public static IntUnaryOperator create(int baseline) {
+        return baseline == 0 ? INSTANCE : INSTANCE.andThen(t -> t + baseline);
+    }
+
+    @Override
+    public int applyAsInt(int t) {
+        return t < 1000 ? lookup[t] : (int) Math.log10(t);
+    }
+}

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/VegasLimitTest.java
@@ -58,7 +58,7 @@ public class VegasLimitTest {
     @Test
     public void decreaseSmoothing() {
         VegasLimit limit = VegasLimit.newBuilder()
-            .decrease(current -> current / 2)
+            .decreaseFunction(current -> current / 2)
             .smoothing(0.5)
             .initialLimit(100)
             .maxConcurrency(200)
@@ -78,9 +78,32 @@ public class VegasLimitTest {
     }
 
     @Test
+    public void decreaseSmoothingDeprecatedBuilderMethod() {
+        @SuppressWarnings("deprecation")
+        VegasLimit limit = VegasLimit.newBuilder()
+                .decrease(current -> current / 2)
+                .smoothing(0.5)
+                .initialLimit(100)
+                .maxConcurrency(200)
+                .build();
+
+        // Pick up first min-rtt
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(10), 100, false);
+        Assert.assertEquals(100, limit.getLimit());
+
+        // First decrease
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(20), 100, false);
+        Assert.assertEquals(75, limit.getLimit());
+
+        // Second decrease
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(20), 100, false);
+        Assert.assertEquals(56, limit.getLimit());
+    }
+
+    @Test
     public void decreaseWithoutSmoothing() {
         VegasLimit limit = VegasLimit.newBuilder()
-            .decrease(current -> current / 2)
+            .decreaseFunction(current -> current / 2)
             .initialLimit(100)
             .maxConcurrency(200)
             .build();
@@ -89,6 +112,28 @@ public class VegasLimitTest {
         limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(10), 100, false);
         Assert.assertEquals(100, limit.getLimit());
         
+        // First decrease
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(20), 100, false);
+        Assert.assertEquals(50, limit.getLimit());
+
+        // Second decrease
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(20), 100, false);
+        Assert.assertEquals(25, limit.getLimit());
+    }
+
+    @Test
+    public void decreaseWithoutSmoothingDeprecatedBuilderMethod() {
+        @SuppressWarnings("deprecation")
+        VegasLimit limit = VegasLimit.newBuilder()
+                .decrease(current -> current / 2)
+                .initialLimit(100)
+                .maxConcurrency(200)
+                .build();
+
+        // Pick up first min-rtt
+        limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(10), 100, false);
+        Assert.assertEquals(100, limit.getLimit());
+
         // First decrease
         limit.onSample(0, TimeUnit.MILLISECONDS.toNanos(20), 100, false);
         Assert.assertEquals(50, limit.getLimit());

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/functions/Log10RootIntFunctionTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/limit/functions/Log10RootIntFunctionTest.java
@@ -1,0 +1,26 @@
+package com.netflix.concurrency.limits.limit.functions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.IntUnaryOperator;
+
+public class Log10RootIntFunctionTest {
+    @Test
+    public void test0Index() {
+        IntUnaryOperator func = Log10RootIntFunction.create(0);
+        Assert.assertEquals(1, func.applyAsInt(0));
+    }
+
+    @Test
+    public void testInRange() {
+        IntUnaryOperator func = Log10RootIntFunction.create(0);
+        Assert.assertEquals(2, func.applyAsInt(100));
+    }
+
+    @Test
+    public void testOutofLookupRange() {
+        IntUnaryOperator func = Log10RootIntFunction.create(0);
+        Assert.assertEquals(4, func.applyAsInt(10000));
+    }
+}


### PR DESCRIPTION
Switch to IntUnaryOperator and DoubleUnaryOperator in VegasLimit to avoid unnecessary boxing. Additionally, reduced repeated reads of volatile fields.