### PR TITLE
Expose configured backlog timeout in LifoBlockingLimiter

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/BlockingLimiter.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limiter/BlockingLimiter.java
@@ -67,7 +67,14 @@ public final class BlockingLimiter<ContextT> implements Limiter<ContextT> {
         this.delegate = limiter;
         this.timeout = timeout;
     }
-    
+
+    /**
+     * Returns the timeout used when blocking to acquire a permit.
+     */
+    public Duration getTimeout() {
+        return timeout;
+    }
+
     private Optional<Listener> tryAcquire(ContextT context) {
         final Instant deadline = Instant.now().plus(timeout);
         synchronized (lock) {


### PR DESCRIPTION
Adds a simple getter, `getFixedBacklogTimeoutMillis()`, to `LifoBlockingLimiter` so the fixed backlog timeout configured via the builder can be inspected and serialized.

This does not change limiter behavior; it only exposes existing configuration for introspection and tooling.