### PR TITLE
Add time unit to Limit#onSample

### DIFF
--- a/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/Limit.java
+++ b/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/Limit.java
@@ -35,8 +35,8 @@ public interface Limit {
 
     /**
      * Update the limiter with a sample
-     * @param startTime
-     * @param rtt
+     * @param startTime start time in nanoseconds
+     * @param rtt round trip time in nanoseconds
      * @param inflight
      * @param didDrop
      */


### PR DESCRIPTION
This simple commit adds the proper time unit (nanos) to the Javadoc for `Limit#onSample`.

I made a mistake by supplying milliseconds; I hope this prevents others from doing the same.

This PR could be extended in two ways:

1. Suffix all variables throughout the code base with the required time unit, e.g., `Limit#onSample(long startTimeNanos, long rttNanos, int inflight, boolean didDrop);` and many more places (where no `TimeUnit` parameter is given).
2. Run Checker Framework's Units checker on the code base: https://checkerframework.org/manual/#units-annotations.