### PR TITLE
BlockingAdaptiveExecutor does not block by default

### DIFF
--- a/concurrency-limits-core/build.gradle
+++ b/concurrency-limits-core/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     testCompileOnly "junit:junit:${jUnitLegacyVersion}"
     testImplementation "org.slf4j:slf4j-log4j12:${slf4jVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${jUnitVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${jUnitVersion}"
 }

--- a/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/executors/BlockingAdaptiveExecutorTest.java
+++ b/concurrency-limits-core/src/test/java/com/netflix/concurrency/limits/executors/BlockingAdaptiveExecutorTest.java
@@ -1,0 +1,31 @@
+package com.netflix.concurrency.limits.executors;
+
+import static org.mockito.Mockito.when;
+
+import com.netflix.concurrency.limits.Limiter;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BlockingAdaptiveExecutorTest {
+
+    @Mock
+    private Limiter<Void> limiter;
+
+    @Test
+    public void shouldBlock() {
+        when(limiter.acquire(null)).thenReturn(Optional.empty());
+
+        BlockingAdaptiveExecutor executor = BlockingAdaptiveExecutor.newBuilder().limiter(limiter).executor(Runnable::run).build();
+
+        AtomicBoolean executed = new AtomicBoolean();
+        executor.execute(() -> executed.set(true));
+
+        Assert.assertTrue(executed.get());
+    }
+}


### PR DESCRIPTION
This test shows that by default `BlockingAdaptiveExecutor` does not block.

The only way to make the executor block is by calling a deprecated constructor at https://github.com/Netflix/concurrency-limits/blob/main/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/executors/BlockingAdaptiveExecutor.java#L117.

I am not sure that this can be fixed in a backwards compatible way, but the actual result is unexpected as both the Javadoc and class name say there is blocking behavior.

Executing the newly provided JUnit tests gives a `RejectedExecutionException` instead of blocking the calling thread.

This PR shows the issue described in https://github.com/Netflix/concurrency-limits/issues/154.